### PR TITLE
Удалена конструкция «более лучший»

### DIFF
--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -505,7 +505,7 @@ const TasksListPage = () => {
   /**
    * Запрашиваем данные при загрузке страницы
    * @remark Является плохой практикой в мире effector и представлено здесь - лишь для наглядной демонстрации
-   * Как более лучшая альтернатива - фетчить через event.pageMounted или reflect
+   * Лучше фетчить через event.pageMounted или reflect
    */
   useEffect(() => taskModel.effects.getTasksListFx(), []);
 
@@ -737,7 +737,7 @@ const TaskDetailsPage = (props: Props) => {
   /**
    * Запрашиваем данные по задаче
    * @remark Является плохой практикой в мире effector и представлено здесь - лишь для наглядной демонстрации
-   * Как более лучшая альтернатива - фетчить через event.pageMounted или reflect
+   * Лучше фетчить через event.pageMounted или reflect
    */
     useEffect(() => taskModel.getTaskByIdFx({ taskId }), [taskId]);
 


### PR DESCRIPTION
## CHANGELOG

- Убавил использование конструкции «более лучший»

**Мотивация:**
Обычно Сложная сравнительная степень образуется с полной формой положительной степени прилагательного. Например, «более хороший». Для превосходной формы прилагательного это не работает.

_Простите за духоту._

## Чеклист

- [x] Если при работе с документацией потребовалось использовать **github-дискуссии, то стоит их прикрепить как see-also источники**
- [x] Если PR связан с задачей, то необходимо проверить, что **все требования по задаче выполнены**
- [x] Перед тем, как отправлять изменения на ревью, **нужно провести self-review своих изменений**
- [x] Перед тем, как отправлять изменения на ревью, **нужно дождаться CI-проверок**
- [x] Перед тем, как отправлять изменения на ревью, **нужно дать краткое описание изменений**
