### PR TITLE
CONTRIB: Remove the checklist to make the PR template friendlier

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,31 @@
-## CHANGELOG
+# Changelog
 
-<!-- 1. Describe the proposed changes in a couple of sentences/paragraphs -->
+<!-- 
+  Briefly describe the proposed changes below. 
+  Numbered lists work best. 
+  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
 
-- Added ...smth...
-- Fixed ...smth...
-
-<!-- Screenshots/Screencasts are welcome -->
-
-## Checklist
-
-<!-- 2. Before submitting changes for review, go over the checklist and mark the necessary items at the end -->
-
-<!--
-Our common goal is to reduce review costs and achieve consistency in the code base. 🤙 
-Let's appreciate each other's time =)
+  If these changes were previously discussed in an issue or discussion,
+  please, leave a reference to it 🔖.
 -->
 
-- [ ] I reviewed **[CONTRIBUTING guidelines](https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md)**
-- [ ] I did a **[self-review of the changes](https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/)**
-- [ ] I gave a **brief description of the changes**
-- [ ] I awaited for **CI checks**
-- [ ] I specified **related materials** if needed (discussion/issue/pull-request...)
-- [ ] **All requirements for the related issue are resolved** if issue exists
+
+
+
+
+<!-- 
+  Hi from the Feature Sliced Design core team! 👋
+
+  Thank you for taking the time to contribute.
+  We have a set of guidelines for contibutors that you might want to read:
+
+    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md
+
+  We encourage self-reviewing the changes before submitting a PR ✅. 
+  Here's a nice article that has some pro-tips:
+
+    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
+
+  If your PR fixes an issue number N, write "Closes #N" at the end.
+  Please make sure to address all parts of the issue if you write that! 
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,25 @@
-# Changelog
+## Background
+
+<!-- 
+  Briefly describe what problem this PR is solving. 
+  If these changes were previously discussed in an issue or discussion,
+  please, leave a reference to it 🔖.
+  
+  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
+  That will automatically close that issue, once PR is merged.
+  Please make sure to address all parts of the issue if you write that!
+-->
+
+
+
+
+## Changelog
 
 <!-- 
   Briefly describe the proposed changes below. 
   Numbered lists work best. 
   If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-
-  If these changes were previously discussed in an issue or discussion,
-  please, leave a reference to it 🔖.
 -->
-
 
 
 
@@ -25,7 +36,5 @@
   Here's a nice article that has some pro-tips:
 
     https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
-
-  If your PR fixes an issue number N, write "Closes #N" at the end.
-  Please make sure to address all parts of the issue if you write that! 
+    
 -->


### PR DESCRIPTION
## CHANGELOG

- Removed the checklist from the template
- Removed CAPS from the Changelog heading
- Sprinkled in some emojis and lightened up the language


## Checklist

<!-- 2. Before submitting changes for review, go over the checklist and mark the necessary items at the end -->

<!--
Our common goal is to reduce review costs and achieve consistency in the code base. 🤙 
Let's appreciate each other's time =)
-->

- [x] I reviewed **[CONTRIBUTING guidelines](https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md)**
- [x] I did a **[self-review of the changes](https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/)**
- [x] I gave a **brief description of the changes**
- [x] I awaited for **CI checks**
- [x] I specified **related materials** if needed (discussion/issue/pull-request...)
- [x] **All requirements for the related issue are resolved** if issue exists

---

## Reasoning

1. Removing CAPS from the Changelog
   Looks calmer and more consistent with the other heading (even though I removed the other one)
2. Removing the sample list that says "Added smth, fixed smth"
   It gets in the way because it has to be deleted/rewritten. The only benefit I see from it is to teach Markdown lists, but I don't think we should make effort towards that.  
   **Proposed solution**: Mention in the comment that lists work best.
3. Removing the checklist
   I moved all of the points of the checklist into other places which I believe to be more appropriate.
   
   1. Contributing guidelines
      Moved that into a P.S. comment because it is mostly useful to first-time contributors.
   2. Self-review
      Moved that into a P.S. comment too, and made it friendlier.
   3. Brief description
      This is already covered by the first comment, so I just removed it.
   4. CI checks
      The CI checks aren't started until the PR is created, this requirement simply can't be fulfilled. Removed it completely, the CI checks are hard not to notice, GitHub does a wonderful job at that.
   5. Related materials and requirements
      Moved to the description comment.

## Preview

When rendered, it's just a heading. Here's how it looks:

> # Changelog

That's good because it gives more focus to what's actually written by the author of a PR. 

<details>
<summary>And here's what it looks like for contributors in the editor</summary>

```
# Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.

  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
-->





<!-- 
  Hi from the Feature Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/

  If your PR fixes an issue number N, write "Closes #N" at the end.
  Please make sure to address all parts of the issue if you write that! 
-->
```

</details>