### PR TITLE
PROMO-481: Correct the FSD spelling to the official one across all pages

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/get-started/quick-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/get-started/quick-start.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Quick start
 
-Let's consider the application of **feature-sliced** on the example of TodoApp
+Let's consider the application of **Feature-Sliced Design** on the example of TodoApp
 
 - At first, we will prepare application basely (bootstrap, routing, styles)
 - Then we will consider - how the concepts of the methodology help *flexibly and effectively design business logic* without unnecessary costs

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/examples/auth.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/examples/auth.mdx
@@ -397,7 +397,7 @@ Therefore, you need to be able to **correctly allocate the scope of the module's
 
 ## See also
 
-- [Discussion "The applicability of feature-sliced in combat"](https://github.com/feature-sliced/documentation/discussions/65) (*there are also examples with viewer* inside)
+- [Discussion "The applicability of Feature-Sliced Design in combat"](https://github.com/feature-sliced/documentation/discussions/65) (*there are also examples with viewer* inside)
 - [Question about the user's profile and identity (community-chat)](https://t.me/feature_sliced/342)
 - [Explanation about UIKIT#Card and User#Card (community-chat)](https://t.me/feature_sliced/552)
 


### PR DESCRIPTION
## Background

Closes #481. Ran a case-insensitive search for `feature sliced` and `feature-sliced` and reviewed all results.

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->




## Changelog

- Fixed all occurences of the brand name to the official "Feature-Sliced Design"

One of the fixes references this discussion — https://github.com/feature-sliced/documentation/discussions/65, which has an incorrect spelling in the name. We should fix that there as well, perhaps

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->




<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
