### PR TITLE
fix(basics): widget typo in structure

### DIFF
--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/basics.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/basics.md
@@ -91,7 +91,7 @@ sidebar_position: 1
     |   ...                     #
     |                           #
     ├── widgets/                # Layer: Виджеты
-    |   ├── {some-feature}/     #     Slice: (н-р виджет Header)
+    |   ├── {some-widget}/      #     Slice: (н-р виджет Header)
     |   |   ├── lib/            #         Segment: Инфраструктурная-логика (helpers/utils)
     |   |   ├── model/          #         Segment: Бизнес-логика
     |   |   └── ui/             #         Segment: UI-логика


### PR DESCRIPTION
## Background

In russian translation was typo on widgets in structure
![image](https://user-images.githubusercontent.com/44724024/187067458-a19e01b9-90c6-46f4-a3cf-baf5c008d189.png)



## Changelog

Fixed typo in widgets
![image](https://user-images.githubusercontent.com/44724024/187067527-83d6012a-8a1f-477c-b0a1-5f99454641f0.png)

