### PR TITLE
[privacy.md] grammar fixes

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/privacy.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/privacy.md
@@ -1,6 +1,6 @@
 # Privacy
 
-**We use cookies for collect data about documentation usage (only for further analytics and improvement of the site, and for no other purpose)**
+**We use cookies to collect data about documentation usage (only for further analytics and improvement of the site, and for no other purpose)**
 
 The only plugins this site relies on are [@docusaurus/plugin-google-analytics](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-analytics) and [docusaurus-plugin-hotjar](https://github.com/symblai/docusaurus-plugin-hotjar). We only use the traffic data provided by [Google Analystics](https://analytics.google.com/) and [Hotjar](https://www.hotjar.com/) to collect feedback from you and refine your user experience.
 
@@ -11,7 +11,7 @@ This page is not a legal notice, please refer to [Google Analystics](https://ana
 **Who will have access to this metrics data?**
 
 - Core-team of methodology
-- Google Analytics, which we relies on for analyze service usage [(more...)](https://www.google.com/analytics/terms/us.html)
-- Hotjar, which we relies on for collect usage feedback [(more...)](https://help.hotjar.com/hc/en-us/categories/360003405813)
+- Google Analytics, which we rely on for analyze service usage [(more...)](https://www.google.com/analytics/terms/us.html)
+- Hotjar, which we rely on for collect usage feedback [(more...)](https://help.hotjar.com/hc/en-us/categories/360003405813)
 
 ![feature-sliced-banner](/img/banner.jpg)


### PR DESCRIPTION
removed not required -s(-es) endings

## Background

Removed unnecessary -s(-es) endings on privacy page





## Changelog

Removed unnecessary -s(-es) endings on privacy page
