### PR TITLE
Fix broken link documentation/decomposition.md

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/reference/units/decomposition.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/reference/units/decomposition.md
@@ -232,7 +232,7 @@ However, as a result of [discussions and analysis of extensive experience][disc-
 [ref-layers]: /docs/reference/units/layers
 [ref-segments]: /docs/reference/units/segments
 [ref-low-coupling]: /docs/reference/isolation/coupling-cohesion
-[ref-grouping]: /docs/reference/units/layers/features#structural-grouping-features
+[ref-grouping]: /docs/reference/units/layers/features#structural-grouping-of-features
 
 [disc-src]: https://github.com/feature-sliced/documentation/discussions/31
 


### PR DESCRIPTION
Fix broken link, https://feature-sliced.design/docs/reference/units/layers/features#structural-grouping-features, does not redirect to the right part of article, but https://feature-sliced.design/docs/reference/units/layers/features#structural-grouping-of-features does.

## Background

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->




## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->




<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
