### PR TITLE
Fix name collisions documentation/tutorial.md

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -424,7 +424,7 @@ At the same time, a higher-level logic is built on the basis of the underlying l
 Each implemented module must provide its own [public interface][refs-public-api] for use:
 
 ```ts title={layer}/foo/index.ts
-export { FooCard, FooThumbnail, ... } from "./ui";
+export { Card as FooCard, Thumbnail as FooThumbnail, ... } from "./ui";
 export * as fooModel from "./model"; 
 ```
 
@@ -435,7 +435,7 @@ If you need named namespace exports for the Public API declaration, you can look
 Or, as an alternative, use a more detailed design
 
 ```ts title={layer}/foo/index.ts
-import { FooCard, FooThumbnail, ... } from "./ui";
+import { Card as FooCard, Thumbnail as FooThumbnail, ... } from "./ui";
 import * as fooModel from "./model"; 
 
 export { FooCard, FooThumbnail, fooModel };

--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -422,7 +422,7 @@ import { Card } from "antd"; // ~ "shared/ui/card"
 Каждый реализуемый модуль должен предоставлять к использованию свой [публичный интерфейс][refs-public-api]:
 
 ```ts title={layer}/foo/index.ts
-export { FooCard, FooThumbnail, ... } from "./ui";
+export { Card as FooCard, Thumbnail as FooThumbnail, ... } from "./ui";
 export * as fooModel from "./model"; 
 ```
 
@@ -433,7 +433,7 @@ export * as fooModel from "./model";
 Либо же, как альтернатива, использовать более развернутую конструкцию
 
 ```ts title={layer}/foo/index.ts
-import { FooCard, FooThumbnail, ... } from "./ui";
+import { Card as FooCard, Thumbnail as FooThumbnail, ... } from "./ui";
 import * as fooModel from "./model"; 
 
 export { FooCard, FooThumbnail, fooModel };


### PR DESCRIPTION
Names collisions should be resolved at the level of public interface, not implementation. Here it exports directly FooCard, but it should export Card as FooCard, the same with FooThumbnail.
Source: https://feature-sliced.design/docs/reference/public-api#resolution-of-collisions

## Background

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->




## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->




<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
