### PR TITLE
Fix: Added ubuntu-700 font-face

### DIFF
--- a/src/app/theme.scss
+++ b/src/app/theme.scss
@@ -1,5 +1,6 @@
 @import "@fontsource/overpass/400.css";
 @import "@fontsource/ubuntu/400.css";
+@import "@fontsource/ubuntu/700.css";
 
 /* https://docusaurus.io/docs/styling-layout */
 


### PR DESCRIPTION
## Background

Closes #544 

## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->

Before (Chrome):

<img width="820" alt="chrome_current" src="https://user-images.githubusercontent.com/19520678/210288141-3b5bf311-cdeb-4b4e-8f56-4feeabaa1e77.png">

Before (Safari):

<img width="824" alt="safari_current" src="https://user-images.githubusercontent.com/19520678/210288155-12a28796-b6ce-40ab-945a-9bed2c21363b.png">


✅ After:

<img width="821" alt="new" src="https://user-images.githubusercontent.com/19520678/210288173-b3681493-8f4d-448c-820d-a6714895096a.png">


<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
