### PR TITLE
chore(copyright): updated current copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2022 Feature-Sliced Design core-team
+Copyright (c) 2018-2023 Feature-Sliced Design core-team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -56,7 +56,7 @@
         "description": "The label of footer link with label=GitHub linking to https://github.com/feature-sliced"
     },
     "copyright": {
-        "message": "Copyright © 2018-2022  Feature-Sliced Design",
+        "message": "Copyright © 2018-2023  Feature-Sliced Design",
         "description": "The footer copyright"
     }
 }

--- a/i18n/ru/docusaurus-theme-classic/footer.json
+++ b/i18n/ru/docusaurus-theme-classic/footer.json
@@ -56,7 +56,7 @@
         "description": "The label of footer link with label=GitHub linking to https://github.com/feature-sliced"
     },
     "copyright": {
-        "message": "Copyright © 2018-2022  Feature-Sliced Design",
+        "message": "Copyright © 2018-2023  Feature-Sliced Design",
         "description": "The footer copyright"
     }
 }


### PR DESCRIPTION
## Background
2022 year in the footer of the docs website and in the LICENSE

![image](https://user-images.githubusercontent.com/76000345/214022029-5a27eb42-2076-4c83-bc93-748838aa8dec.png)

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->




## Changelog
updated current copyright and LICENSE year to 2023
<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->




<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
