### PR TITLE
Add widgets to Layers order of Decomposition page

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/reference/units/decomposition.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/reference/units/decomposition.md
@@ -31,7 +31,7 @@ If you look at the order of the layers , you can distinguish two general pattern
 
 #### By the level of knowledge/responsibility
 
-`app` > `processes` > `pages` > `features` > `entities` > `shared`
+`app` > `processes` > `pages` > `widgets` > `features` > `entities` > `shared`
 
 The module "knows" only about itself and the underlying modules, but not the ones lying above
 
@@ -39,7 +39,7 @@ The module "knows" only about itself and the underlying modules, but not the one
 
 #### By the level of danger of changes
 
-`shared` > `entities` > `features` > `pages` > `processes` > `app`
+`shared` > `entities` > `features` > `widgets` > `pages` > `processes` > `app`
 
 The lower the module is located , the more dangerous it is to make changes to it
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/units/decomposition.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/units/decomposition.md
@@ -31,7 +31,7 @@ sidebar_position: 3
 
 #### По уровню знания/ответственности {#by-the-level-of-knowledgeresponsibility}
 
-`app` > `processes` > `pages` > `features` > `entities` > `shared`
+`app` > `processes` > `pages` > `widgets` > `features` > `entities` > `shared`
 
 Модуль "знает" только про себя и нижележащие модули, но не вышележащие
 
@@ -39,7 +39,7 @@ sidebar_position: 3
 
 #### По уровню опасности изменений {#by-the-level-of-danger-of-changes}
 
-`shared` > `entities` > `features` > `pages` > `processes` > `app`
+`shared` > `entities` > `features` > `widgets` > `pages` > `processes` > `app`
 
 Чем ниже расположен модуль - тем опаснее вносить в него изменения
 


### PR DESCRIPTION
## Background
Layers order section on [Decomposition page](https://feature-sliced.design/docs/reference/units/decomposition) lacks the `widgets` layer.

## Changelog
1. Added `widgets` to the English version of Decomposition page.
2. Added `widgets` to the Russian version of Decomposition page.