### PR TITLE
fix: elaborate on the import rule on layers

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/reference/layers.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/reference/layers.mdx
@@ -31,11 +31,11 @@ You don't have to use every layer in your project — only add them if you think
 
 ## Import rule on layers
 
-The difference in dependency is enforced with **the import rule on layers**:
+Layers are made up of _slices_ — highly cohesive groups of modules. Feature-Sliced Design promotes low coupling, which is why dependencies between slices are regulated by **the import rule on layers**:
 
-> _A module can only import other modules when they are located on layers strictly below._
+> _A module in a slice can only import other slices when they are located on layers strictly below._
 
-For example, a module in `~/features/aaa` cannot import code from `~/features/bbb`, but can import code from `~/entities` and `~/shared`.
+For example, in `~/features/aaa`, `aaa` is the slice, so a file `~/features/aaa/api/request.ts` cannot import code from any module in `~/features/bbb`, but can import code from `~/entities` and `~/shared`, as well as any sibling code from `~/features/aaa`.
 
 ## Layer definitions
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/layers.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/layers.mdx
@@ -31,11 +31,14 @@ pagination_next: reference/slices-segments
 
 ## Правило импортов для слоёв
 
-Разница в зависимостях обеспечивается **правилом импортов для слоёв**:
+Слои состоят из _слайсов_ — сильно сцепленных групп модулей. Feature-Sliced Design поддерживает низкую связанность, поэтому зависимости между слайсами регулируются **правилом импортов для слоёв**:
 
-> _Модуль может импортировать другие модули, только если они расположены на слоях строго ниже._
+For example, in `~/features/aaa`, `aaa` is the slice, so a file `~/features/aaa/api/request.ts` cannot import code from any module in `~/features/bbb`, but can import code from `~/entities` and `~/shared`, as well as any sibling code from `~/features/aaa`.
 
-Например, модуль в `~/features/aaa` не может импортировать код из `~/features/bbb`, но может импортировать код из `~/entities` и `~/shared`.
+
+> _Модуль в слайсе может импортировать другие слайсы только в том случае, если они расположены на слоях строго ниже._
+
+Например, в `~/features/aaa`, слайсом является `aaa`, поэтому файл `~/features/aaa/api/request.ts` не может импортировать код ни из какого модуля в папку из `~/features/bbb`, но может импортировать код из `~/entities` и `~/shared`, а также из соседних модулей в `~/features/aaa`.
 
 ## Определения слоёв
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/reference/layers.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/reference/layers.mdx
@@ -33,9 +33,6 @@ pagination_next: reference/slices-segments
 
 Слои состоят из _слайсов_ — сильно сцепленных групп модулей. Feature-Sliced Design поддерживает низкую связанность, поэтому зависимости между слайсами регулируются **правилом импортов для слоёв**:
 
-For example, in `~/features/aaa`, `aaa` is the slice, so a file `~/features/aaa/api/request.ts` cannot import code from any module in `~/features/bbb`, but can import code from `~/entities` and `~/shared`, as well as any sibling code from `~/features/aaa`.
-
-
 > _Модуль в слайсе может импортировать другие слайсы только в том случае, если они расположены на слоях строго ниже._
 
 Например, в `~/features/aaa`, слайсом является `aaa`, поэтому файл `~/features/aaa/api/request.ts` не может импортировать код ни из какого модуля в папку из `~/features/bbb`, но может импортировать код из `~/entities` и `~/shared`, а также из соседних модулей в `~/features/aaa`.


### PR DESCRIPTION
## Background

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->

The current version of the import rule on layers goes like this:

> A module can only import other modules when they are located on layers strictly below.

Nothing about the fact that imports inside the slice are allowed. That's no good.

## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->

1. Add more details to the rule so that it actually makes sense


<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
