### PR TITLE
fix: add another missing redirect

### DIFF
--- a/config/docusaurus/routes.js
+++ b/config/docusaurus/routes.js
@@ -140,6 +140,11 @@ const LEGACY_ROUTES = [
                 to: "/docs/reference/layers",
             },
             {
+                title: "Layer overview",
+                from: "/docs/reference/layers/overview",
+                to: "/docs/reference/layers",
+            },
+            {
                 title: "App layer",
                 from: "/docs/reference/units/layers/app",
                 to: "/docs/reference/layers",


### PR DESCRIPTION
## Background

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->

Our ESLint config links to a non-existent URL, no bueno


## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->

1. Redirect from `/reference/layers/overview` to `/reference/layers`


<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
