### PR TITLE
fix: set correct attribute to Discussions section in footer, add translations

### DIFF
--- a/config/docusaurus/footer.js
+++ b/config/docusaurus/footer.js
@@ -18,7 +18,7 @@ const footer = {
                 { label: "Documentation", to: "/docs" },
                 { label: "Community", to: "/community" },
                 { label: "Help", to: "/nav" },
-                { label: "Discussions", to: `${GITHUB_DOCS}/discussions` },
+                { label: "Discussions", href: `${GITHUB_DOCS}/discussions` },
             ],
         },
         {

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -19,6 +19,14 @@
         "message": "Discussions",
         "description": "The label of footer link with label=Discussions linking to https://github.com/feature-sliced/documentation/discussions"
     },
+    "link.item.label.Community": {
+      "message": "Community",
+      "description": "The label of the footer link with label=Community linking to /community"
+    },
+    "link.item.label.Help": {
+      "message": "Help",
+      "description": "The label of the footer link with label=Help linking to /nav"
+    },
     "link.item.label.License": {
         "message": "License",
         "description": "The label of footer link with label=License linking to LICENSE"

--- a/i18n/ru/docusaurus-theme-classic/footer.json
+++ b/i18n/ru/docusaurus-theme-classic/footer.json
@@ -15,6 +15,14 @@
         "message": "Документация",
         "description": "The label of footer link with label=Документация linking to /docs"
     },
+    "link.item.label.Community": {
+      "message": "Сообщество",
+      "description": "The label of the footer link with label=Community linking to /community"
+    },
+    "link.item.label.Help": {
+      "message": "Помощь",
+      "description": "The label of the footer link with label=Help linking to /nav"
+    },
     "link.item.label.Discussions": {
         "message": "Обсуждения",
         "description": "The label of footer link with label=Обсуждения linking to https://github.com/feature-sliced/documentation/discussions"


### PR DESCRIPTION
## Background

The link to the "Discussions" section in GitHub in Footer was pointed with the "to" attribute as it's a path inside a router. That can cause some trouble in future versions. And also, because of this, the link was missing the external link icon
![image](https://github.com/feature-sliced/documentation/assets/4656313/b570f413-b7f2-42ec-b1a7-27e42b369e5b)

Also in the footer translations were missing items for the Help and Community links.

## Changelog

 1. Changed link attribute to Discussions section in the Footer
 2. Added translation items for Help and Community links.

