### PR TITLE
Update coupling-cohesion.md

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/reference/isolation/coupling-cohesion.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/reference/isolation/coupling-cohesion.md
@@ -30,8 +30,8 @@ List component will not itself define the look and structure of the header compo
 
 ```tsx
 interface ListProps {
-    Header: Component;
-    Items: Component;
+    Header: React.ReactNode;
+    Items: React.ReactNode;
 }
 
 const List: Component<ListProps> = ({ Header, Items }) => (


### PR DESCRIPTION
Fixed typo in props type declaration

## Background

PR solves misunderstanding that can occur while reading the docs page of [FSD](https://feature-sliced.design/docs/reference/isolation/coupling-cohesion#laying-the-extensibility)

## Changelog

Changed Component to the React.ReactNode type

<img width="1440" alt="Снимок экрана 2023-06-15 в 10 43 13" src="https://github.com/feature-sliced/documentation/assets/48365412/5d5cc5f9-bc5b-4838-9531-39ae5f8f1783">

