### PR TITLE
Docs: update block codes at "Let's form the routes" section

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -263,7 +263,7 @@ const TestPage = lazy(() => import("./test"));
 export const Routing = () => {
     return (
         <Routes>
-           <Route exact path="/" element={<TestPage/>} />
+           <Route path="/" element={<TestPage/>} />
            <Route path="*" element={<Navigate to="/" />} />
         </Routes>
     );

--- a/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -256,16 +256,16 @@ export default TestPage;
 ```tsx title=pages/index.tsx
 // Or use @loadable/component, as part of the tutorial - uncritically
 import { lazy } from "react";
-import { Route, Switch, Redirect } from "react-router-dom";
+import { Route, Routes, Navigate } from "react-router-dom";
 
 const TestPage = lazy(() => import("./test"));
 
 export const Routing = () => {
     return (
-        <Switch>
-            <Route exact path="/" component={TestPage} />
-            <Redirect to="/" />
-        </Switch>
+        <Routes>
+           <Route exact path="/" element={<TestPage/>} />
+           <Route path="*" element={<Navigate to="/" />} />
+        </Routes>
     );
 };
 ```

--- a/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -263,8 +263,8 @@ const TestPage = lazy(() => import("./test"));
 export const Routing = () => {
     return (
         <Routes>
-           <Route path="/" element={<TestPage/>} />
-           <Route path="*" element={<Navigate to="/" />} />
+            <Route path="/" element={<TestPage/>} />
+            <Route path="*" element={<Navigate to="/" />} />
         </Routes>
     );
 };

--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -263,7 +263,7 @@ const TestPage = lazy(() => import("./test"));
 export const Routing = () => {
     return (
         <Routes>
-            <Route exact path="/" element={<TestPage/>} />
+            <Route path="/" element={<TestPage/>} />
             <Route path="*" element={<Navigate to="/" />} />
         </Routes>
     );

--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -256,16 +256,16 @@ export default TestPage;
 ```tsx title=pages/index.tsx
 // Либо использовать @loadable/component, в рамках туториала - некритично
 import { lazy } from "react";
-import { Route, Switch, Redirect } from "react-router-dom";
+import { Route, Routes, Navigate } from "react-router-dom";
 
 const TestPage = lazy(() => import("./test"));
 
 export const Routing = () => {
     return (
-        <Switch>
-            <Route exact path="/" component={TestPage} />
-            <Redirect to="/" />
-        </Switch>
+        <Routes>
+            <Route exact path="/" element={<TestPage/>} />
+            <Route path="*" element={<Navigate to="/" />} />
+        </Routes>
     );
 };
 ```


### PR DESCRIPTION
## Background

Update block codes at ["Let's form the routes" section](https://feature-sliced.design/ru/docs/get-started/tutorial#lets-form-the-routes), which allows us to see and use actual version and state of `react-router-dom` library.

### Remark: 

Starting from v6 version,  `react-router-dom`  marked `Switch` and `Redirect` (that placed inside of `Switch`) as deprecated components. As a recomendation `Switch` should be replaced by `Routes`, and `Redirect` by `Navigate`.

### Related links from [`react-router-dom` documentation](https://reactrouter.com/en/main):

* [Upgrade all `<Switch>` elements to `<Routes>`](https://reactrouter.com/en/main/upgrading/v5#upgrade-all-switch-elements-to-routes)
* [Advantages of `<Route element>`](https://reactrouter.com/en/main/upgrading/v5#advantages-of-route-element)
* [Remove `<Redirect>`s inside `<Switch>`](https://reactrouter.com/en/main/upgrading/v5#remove-redirects-inside-switch)

<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
