### PR TITLE
docs: Remove code block, which contained import of common antd styles

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -299,10 +299,6 @@ To simplify the tutorial, we will use the ready-made UIKit from [AntDesign](http
 $ npm i antd @ant-design/icons
 ```
 
-```ts title=app/styles/index.scss
-@import 'antd/dist/antd.css';
-```
-
 :::tip
 
 But you can use **any other UIKit** or **create your own** by placing the components in `shared/ui` - this is where it is recommended to place UIKit of application:

--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -299,10 +299,6 @@ const App = () => (
 $ npm i antd @ant-design/icons
 ```
 
-```ts title=app/styles/index.scss
-@import 'antd/dist/antd.css';
-```
-
 :::tip
 
 Но вы можете использовать **любой другой UIKit** или же **создать собственный**, расположив компоненты в `shared/ui` - именно там рекомендуется хранить UIKit приложения:


### PR DESCRIPTION
## Background

Remove code block, which contained import of `antd/dist/antd.css`. The main reason why I do so - is that this approach doesn't actual at v5 of antd. 

For proving it, you can read [the list of incompatible changes in v5](https://ant.design/docs/react/migration-v5#incompatible-changes-in-v5) on official site, especially ["Technology adjustment" block](https://ant.design/docs/react/migration-v5#technology-adjustment)

> Css files are no longer included in package. Since CSS-in-JS supports importing on demand, the original `antd/dist/antd.css` has also been abandoned. If you need to reset some basic styles, please import `antd/dist/reset.css`.

<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
