### PR TITLE
feat: enable algolia contextual search

### DIFF
--- a/config/docusaurus/extensions.js
+++ b/config/docusaurus/extensions.js
@@ -134,9 +134,7 @@ const algolia = {
     appId: process.env.ALGOLIA_ID,
     apiKey: process.env.ALGOLIA_KEY,
     indexName: "feature-sliced",
-    // FIXME: При включении отрубает поиск (исправить поздней)
-    // Для поиска с учетом версий (на будущее)
-    contextualSearch: false,
+    contextualSearch: true,
 };
 
 module.exports = { presets, plugins, algolia, metrics };


### PR DESCRIPTION
It was disabled before, I don't know why. All I know is that search in other languages doesn't work and Algolia is such a complicated pile of junk that I'm reaching for anything.

I'm going by [this guide](https://docusaurus.io/docs/search#using-algolia-docsearch) and just resetting everything to defaults