### PR TITLE
fix(docs-i18n-ru): fix typo in example

### DIFF
--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -284,7 +284,7 @@ export function ArticlePreview({ article }) { /* TODO */ }
 
 Поскольку мы пишем на TypeScript, было бы неплохо иметь типизированный объект статьи Article. Если мы изучим сгенерированный `v1.d.ts`, то увидим, что объект Article доступен через `components["schemas"]["Article"]`. Поэтому давайте создадим файл с нашими моделями данных в Shared и экспортируем модели:
 
-```tsx title="shared/models/index.ts"
+```tsx title="shared/api/models.ts"
 import type { components } from "./v1";
 
 export type Article = components["schemas"]["Article"];


### PR DESCRIPTION
## Changelog
  Исправил ошибку в примере, путем приведения её к состоянию как в англоязычной версии туториала.

[EN] В англоязычной версии пример верен. 
https://github.com/feature-sliced/documentation/blob/629b61f06924d8186bb89b42f0a259424c0a76b9/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md?plain=1#L289

[RU] В русскоязычном примере допущена ошибка в пути. 
https://github.com/feature-sliced/documentation/blob/629b61f06924d8186bb89b42f0a259424c0a76b9/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md?plain=1#L287
