### PR TITLE
fix(docs-i18n-ru/en): fix crash on "header" stage in tutorial;

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -827,7 +827,7 @@ export async function getUserFromSession(request: Request) {
   const cookie = request.headers.get("Cookie");
   const session = await sessionStorage.getSession(cookie);
 
-  return session.get("user");
+  return session.get("user") ?? null;
 }
 
 export async function requireUser(request: Request) {

--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -824,7 +824,7 @@ export async function getUserFromSession(request: Request) {
   const cookie = request.headers.get("Cookie");
   const session = await sessionStorage.getSession(cookie);
 
-  return session.get("user");
+  return session.get("user") ?? null;
 }
 
 export async function requireUser(request: Request) {


### PR DESCRIPTION
Привет 👋

Correct: https://github.com/feature-sliced/tutorial-conduit/blob/main/shared/api/auth.server.ts#L51

No correct: [EN](https://github.com/feature-sliced/documentation/blob/master/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md?plain=1#L830 ), [RU](https://github.com/feature-sliced/documentation/blob/master/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md?plain=1#L827)

## Changelog
**Мотивация:**
Строгое следование туториалу (код и структура приложения используется из примеров),  приводит приложение к крашу по завершению [этапа с созданием хедара приложения](https://feature-sliced.design/ru/docs/get-started/tutorial#%D1%85%D1%8D%D0%B4%D0%B5%D1%80).
![crash](https://github.com/feature-sliced/documentation/assets/78823465/a5277466-f078-488b-b47d-a90a2188f5eb)

**Причина:**
Проблема заключается в [предыдущем этапе](https://feature-sliced.design/ru/docs/get-started/tutorial#%D0%B0%D1%83%D1%82%D0%B5%D0%BD%D1%82%D0%B8%D1%84%D0%B8%D0%BA%D0%B0%D1%86%D0%B8%D1%8F), а точнее в примере, где пропустили оператор нулевого слияния ([EN](https://github.com/feature-sliced/documentation/blob/master/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md?plain=1#L830 ), [RU](https://github.com/feature-sliced/documentation/blob/master/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md?plain=1#L827)).

**Решение:**
Добавил пропущенный оператор, приведя строк к виду, как в эталонном репозитории, код которого должен совпадать(в теории) с кодом приложения по окончанию туториала.
https://github.com/feature-sliced/tutorial-conduit/blob/main/shared/api/auth.server.ts#L51

Возможно я что-то упустил и Вы можете предложить свое решение проблемы на этапе с хедером.