### PR TITLE
fix(docs-i18n-ru/en): typo in example

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -1520,7 +1520,7 @@ And with that we are officially done with the feed! Yay!
 First, we need data. Let’s create a loader:
 
 ```bash
-npx fsd pages article-reader -s api
+npx fsd pages article-read -s api
 ```
 
 ```tsx title="pages/article-read/api/loader.ts"

--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -1517,7 +1517,7 @@ export function ArticlePreview({ article }: ArticlePreviewProps) {
 Во-первых, нам нужны данные. Давайте создадим загрузчик:
 
 ```bash
-npx fsd pages article-reader -s api
+npx fsd pages article-read -s api
 ```
 
 ```tsx title="pages/article-read/api/loader.ts"


### PR DESCRIPTION
## Changelog
Исправил внутри слоя `pages` название слайса `article-reader`, согласно объявленной структуре([ru](https://github.com/feature-sliced/documentation/blob/master/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md?plain=1#L34) / [en](https://github.com/feature-sliced/documentation/blob/master/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md?plain=1#L33)) в начале туториала.

Опечатка:
[RU]: https://github.com/feature-sliced/documentation/blob/master/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md?plain=1#L1520-L1523
[EN]: https://github.com/feature-sliced/documentation/blob/master/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md?plain=1#L1523-L1526

