### PR TITLE
Remove obsolete website links from example configurations

### DIFF
--- a/src/pages/examples/_config.ts
+++ b/src/pages/examples/_config.ts
@@ -34,7 +34,6 @@ export const examples: Example[] = [
     {
         title: "Github Client",
         description: "React & GraphQL powered github web-client",
-        website: "http://github-client.gq/",
         source: "https://github.com/ani-team/github-client/tree/workshop/feature-sliced-next",
         preview: require("./img/github-client.png"),
         version: VERSIONS.V2,
@@ -56,7 +55,6 @@ export const examples: Example[] = [
         title: "Todo App (React+Redux)",
         description:
             "QuickStart todo-app example for React developers (Redux version)",
-        website: "https://kxn7cx-3000.preview.csb.app/",
         source: "https://github.com/EliseyMartynov/fs-rtk",
         preview: require("./img/todo-app-react-redux.png"),
         version: VERSIONS.V2,
@@ -66,7 +64,6 @@ export const examples: Example[] = [
     {
         title: "Todo App (Vue 3)",
         description: "QuickStart todo-app example for Vue developers",
-        website: "https://fccls.sse.codesandbox.io/",
         source: "https://github.com/EliseyMartynov/fs-vue",
         preview: require("./img/todo-app-vue.png"),
         version: VERSIONS.V2,
@@ -147,7 +144,6 @@ export const examples: Example[] = [
         title: "Todo App (ReactNative+Redux)",
         description:
             "QuickStart todo-app example for ReactNative(Expo) developers",
-        website: "https://expo.dev/@berdimyradov/todo-app",
         source: "https://github.com/berdimyradov/fs-rn-todo-app",
         preview: require("./img/fs-rn-todo-app.png"),
         version: VERSIONS.V2,
@@ -251,7 +247,6 @@ export const examples: Example[] = [
         title: "Money Flow",
         description:
             "A mobile application for tracking your expenses and incomes.",
-        website: "https://moneyflow.cash",
         source: "https://github.com/moneyflow-dev/moneyflow",
         preview: require("./img/moneyflow.png"),
         version: VERSIONS.V2,
@@ -282,7 +277,6 @@ export const examples: Example[] = [
     {
         title: "VK Audiopad",
         description: "Chrome extension for VK Music",
-        website: "https://github.com/vissh/vkui-audiopad",
         source: "https://github.com/vissh/vkui-audiopad",
         preview: require("./img/vkaudiopad.png"),
         version: VERSIONS.V2,

--- a/src/pages/examples/_config.ts
+++ b/src/pages/examples/_config.ts
@@ -277,7 +277,8 @@ export const examples: Example[] = [
     {
         title: "VK Audiopad",
         description: "Chrome extension for VK Music",
-        website: "https://chrome.google.com/webstore/detail/plclpmphdjmdgmdpfkcmdkmohgpfecip",
+        website:
+            "https://chrome.google.com/webstore/detail/plclpmphdjmdgmdpfkcmdkmohgpfecip",
         source: "https://github.com/vissh/vkui-audiopad",
         preview: require("./img/vkaudiopad.png"),
         version: VERSIONS.V2,

--- a/src/pages/examples/_config.ts
+++ b/src/pages/examples/_config.ts
@@ -277,6 +277,7 @@ export const examples: Example[] = [
     {
         title: "VK Audiopad",
         description: "Chrome extension for VK Music",
+        website: "https://chrome.google.com/webstore/detail/plclpmphdjmdgmdpfkcmdkmohgpfecip",
         source: "https://github.com/vissh/vkui-audiopad",
         preview: require("./img/vkaudiopad.png"),
         version: VERSIONS.V2,


### PR DESCRIPTION
## Overview
This pull request removes several outdated website links from the examples configuration file that were either no longer functioning or redundant due to redirections to the source URLs.

## Changes
- Removed specific website entries that are obsolete or duplicate the source links provided in the configuration.
- Regarding vk audiopad, there was a link in the repository, so I used that and changed it to the website link.

## Rationale
The removal of these links simplifies the information presented in the examples, ensuring that users are not misdirected by inactive or redundant URLs.

## Request for Maintainers
If you find this pull request unnecessary, or if further modifications are required, please feel free to reject or suggest necessary revisions.

## Just to be sure, the test has passed.
```
[INFO] [en] Creating an optimized production build...

✔ Client
  Compiled successfully in 7.01s

✔ Server
  


✔ Client
  Compiled successfully in 3.67s

✔ Server
  

[SUCCESS] Generated static files in "build".
[INFO] [ru] Creating an optimized production build...

✔ Client
  Compiled successfully in 2.93s

✔ Server
  

[SUCCESS] Generated static files in "build/ru".
[INFO] [uz] Creating an optimized production build...

● Client █████████████████████████ cache (99%) shutdown IdleFileCachePlugin
 serialize pack

● Server █████████████████████████ cache (99%) shutdown IdleFileCachePlugin
 stored

[SUCCESS] Generated static files in "build/uz".
```

```
$ eslint --cache "./**/*.{ts,tsx,js,jsx}" && stylelint --cache ./**/*.scss && prettier --check --cache .
Checking formatting...
All matched files use Prettier code style!
```

Thank you for reviewing this proposal！