### PR TITLE
fix: change alias path in the Nuxt guide

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nuxtjs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nuxtjs.mdx
@@ -17,7 +17,7 @@ Add an `alias` object to your config:
 export default defineNuxtConfig({
   devtools: { enabled: true },      // Not related to FSD, enabled at project startup
   alias: {
-    "@": '~/src'
+    "@": '../src'
   },
 })
 ```
@@ -39,7 +39,7 @@ In order for NuxtJS to use the `app` layer for file routing, you need to modify 
 export default defineNuxtConfig({
   devtools: { enabled: true },      // Not FSD related, enabled at project startup
   alias: {
-    "@": '~/src'
+    "@": '../src'
   },
   dir: {
     pages: './src/app/routes'
@@ -101,7 +101,7 @@ You can place layouts inside the `app` layer, to do this you need to modify the 
 export default defineNuxtConfig({
   devtools: { enabled: true },      // Not related to FSD, enabled at project startup
   alias: {
-    "@": '~/src'
+    "@": '../src'
   },
   dir: {
     pages: './src/app/routes',

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/tech/with-nuxtjs.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/tech/with-nuxtjs.mdx
@@ -16,7 +16,7 @@ sidebar_position: 10
 export default defineNuxtConfig({
   devtools: { enabled: true },        // Не относятся к FSD, включёны при старте проекта
   alias: {
-    "@": '~/src'
+    "@": '../src'
   },
 })
 ```
@@ -38,7 +38,7 @@ export default defineNuxtConfig({
 export default defineNuxtConfig({
   devtools: { enabled: true },        // Не относятся к FSD, включёны при старте проекта
   alias: {
-    "@": '~/src'
+    "@": '../src'
   },
   dir: {
     pages: './src/app/routes'
@@ -100,7 +100,7 @@ export { default as HomePage } from './ui/home-page';
 export default defineNuxtConfig({
   devtools: { enabled: true },        // Не относятся к FSD, включёны при старте проекта
   alias: {
-    "@": '~/src'
+    "@": '../src'
   },
   dir: {
     pages: './src/app/routes',


### PR DESCRIPTION
Добрый день!
Поправлен путь алиаса "@".
Если указывать \~, то в tsconfig при сборке указывается буквально "~/src". tsconfig не в курсе что за \~, а поэтому ide (в моём случае vs code) начинает колбасить при импортах.