### PR TITLE
fix: fix a section in the Next.js guide and add an example

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,6 +48,7 @@ module.exports = {
         metadata: cfg.metadata,
 
         imageZoom: {
+            selector: ".markdown :not(a) > img",
             options: {
                 background: "rgb(255 255 255 / 0.3)",
             },

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
@@ -92,21 +92,26 @@ To comply with the principles of FSD, you should treat the NextJS `app` folder i
 to resolve a conflict with the NextJS `pages` folder.
 
 The approach is to move the NextJS `app` folder to the root folder of the project and import the FSD pages into the NextJS `app` folder. This saves
-the FSD project structure inside the `src` folder.
+the FSD project structure inside the `src` folder. You should still also add the `pages` folder to the root, because the App router is compatible with the Pages router.
 
-```sh
+```
 ├── app                # NextJS app folder
+├── pages              # Stub NextJS pages folder
+│   ├── README.md      # Description of why this folder exists
 ├── src
 │   ├── app            # FSD app folder
 │   ├── entities
 │   ├── features
-│   ├── pages
+│   ├── pages          # FSD app folder
 │   ├── shared
 │   ├── widgets
 ```
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)][ext-app-router-stackblitz]
 
 ## See also {#see-also}
 
 - [(Thread) About the pages directory in NextJS](https://t.me/feature_sliced/3623)
 
 [project-knowledge]: /docs/about/understanding/knowledge-types
+[ext-app-router-stackblitz]: https://stackblitz.com/edit/stackblitz-starters-aiez55?file=README.md 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
@@ -91,21 +91,26 @@ App Router стал стабильным в NextJS версии 13.4. App Router
 для устранения конфликта с папкой `pages` NextJS.
 
 Подход заключается в перемещении папки `app` NextJS в корневую папку проекта и импорте страниц FSD в папку `app` NextJS. Это сохраняет
-структуру проекта FSD внутри папки `src`.
+структуру проекта FSD внутри папки `src`. Вам также стоит добавить в корневую папку проекта папку `pages`, потому что App Router совместим с Pages Router.
 
-```sh
+```
 ├── app                # Папка app (NextJS)
+├── pages              # Пустая папка pages (NextJS)
+│   ├── README.md      # Описание того, зачем нужна эта папка
 ├── src
 │   ├── app            # Папка app (FSD)
 │   ├── entities
 │   ├── features
-│   ├── pages
+│   ├── pages          # Папка pages (FSD)
 │   ├── shared
 │   ├── widgets
 ```
+
+[![Открыть в StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)][ext-app-router-stackblitz]
 
 ## См. также {#see-also}
 
 - [(Тред) Про pages директорию в NextJS](https://t.me/feature_sliced/3623)
 
 [project-knowledge]: /docs/about/understanding/knowledge-types
+[ext-app-router-stackblitz]: https://stackblitz.com/edit/stackblitz-starters-aiez55?file=README.md 


### PR DESCRIPTION
## Background

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->

As pointed out in the docs, it's not enough to simply have `app` in the root folder, you must also have `pages`. To ensure that the guide is working as expected, we will also provide a runnable link to a project.


## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->

1. Changed the file structure in the App Router example to include the `pages` folder in the root
2. Added a StackBlitz link with a Next.js project that implements this guide


<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
