### PR TITLE
fix: make the markup in the tutorial valid

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -1608,8 +1608,8 @@ export function ArticleReadPage() {
       <div className="container page">
         <div className="row article-content">
           <div className="col-md-12">
+            <p>{article.article.body}</p>
             <ul className="tag-list">
-              <p>{article.article.body}</p>
               {article.article.tagList.map((tag) => (
                 <li className="tag-default tag-pill tag-outline" key={tag}>
                   {tag}

--- a/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -1605,8 +1605,8 @@ export function ArticleReadPage() {
       <div className="container page">
         <div className="row article-content">
           <div className="col-md-12">
+            <p>{article.article.body}</p>
             <ul className="tag-list">
-              <p>{article.article.body}</p>
               {article.article.tagList.map((tag) => (
                 <li className="tag-default tag-pill tag-outline" key={tag}>
                   {tag}


### PR DESCRIPTION
## Background

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->

Someone left feedback that the markup in our tutorial code is slightly invalid


## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->

1. Move the `<p>` out of the `<ul>` tag list


<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
