### PR TITLE
fix: add/remove website urls in examples

### DIFF
--- a/src/entities/example/index.tsx
+++ b/src/entities/example/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import clsx from "clsx";
 import Image from "@theme/IdealImage";
 import { date } from "@site/src/shared/lib/date";

--- a/src/pages/examples/_config.ts
+++ b/src/pages/examples/_config.ts
@@ -370,7 +370,7 @@ export const examples: Example[] = [
             "An application that helps you quit smoking, published in the App Store and Google. Developed with React Native",
         version: VERSIONS.V2,
         updatedAt: "2024-03-31",
-        website: "https://dontsmoke.vasyl.site/ru",
+        website: "https://dontsmoke.vasyl.site",
         source: "https://github.com/penteleichuk/Moke-Smoke",
         preview: require("./img/moke-smoke.jpg"),
         tech: ["react", "rtk", "persist", "typescript", "firebase"],

--- a/src/pages/examples/_config.ts
+++ b/src/pages/examples/_config.ts
@@ -173,7 +173,6 @@ export const examples: Example[] = [
     {
         title: "Sudoku (React+Effector)",
         description: "A simple crossword of numbers on effector / fsd",
-        website: "https://sudoku-effector.pages.dev/",
         source: "https://github.com/Shiyan7/sudoku-effector",
         preview: require("./img/sudoku.png"),
         version: VERSIONS.V2,
@@ -371,6 +370,7 @@ export const examples: Example[] = [
             "An application that helps you quit smoking, published in the App Store and Google. Developed with React Native",
         version: VERSIONS.V2,
         updatedAt: "2024-03-31",
+        website: "https://dontsmoke.vasyl.site/ru",
         source: "https://github.com/penteleichuk/Moke-Smoke",
         preview: require("./img/moke-smoke.jpg"),
         tech: ["react", "rtk", "persist", "typescript", "firebase"],

--- a/src/pages/examples/_config.ts
+++ b/src/pages/examples/_config.ts
@@ -173,6 +173,7 @@ export const examples: Example[] = [
     {
         title: "Sudoku (React+Effector)",
         description: "A simple crossword of numbers on effector / fsd",
+        website: "https://sudoku-effector.pages.dev/",
         source: "https://github.com/Shiyan7/sudoku-effector",
         preview: require("./img/sudoku.png"),
         version: VERSIONS.V2,
@@ -416,13 +417,14 @@ export const examples: Example[] = [
     },
     {
         title: "Tiny Bunny Mini Game",
-        description: "Mini-game \"21 points\" in the universe of the visual novel \"Tiny Bunny\".",
+        description:
+            'Mini-game "21 points" in the universe of the visual novel "Tiny Bunny".',
         source: "https://github.com/sanua356/tiny-bunny",
         website: "https://sanua356.github.io/tiny-bunny/",
         preview: require("./img/tiny-bunny.png"),
         version: VERSIONS.V2,
         updatedAt: "2024-08-10",
-        tech: ["react", "redux-toolkit", 'typescript'],
+        tech: ["react", "redux-toolkit", "typescript"],
     },
     // Reverse the list (last examples should be at the top)
 ].reverse();


### PR DESCRIPTION
Hi everyone! I looked through all the examples in the documentation and found that some of the website links were broken, and some were in the repository but not listed in the documentation. I fixed that.

- MokeSmoke (add website)
- Sudoky Effector (remove website)