### PR TITLE
fix: correct a layer name typo in the next guide

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
@@ -32,8 +32,8 @@ the FSD project structure inside the `src` folder.
 
 ### Renaming the `pages` layer within the FSD structure
 
-Another way to solve the problem is to rename the `app` layer in the FSD structure to avoid conflicts with the NextJS `pages` folder.
-You can rename the `app` layer in FSD to `views`.
+Another way to solve the problem is to rename the `pages` layer in the FSD structure to avoid conflicts with the NextJS `pages` folder.
+You can rename the `pages` layer in FSD to `views`.
 In that way, the structure of the project in the `src` folder is preserved without contradiction with the requirements of NextJS.
 
 ```sh
@@ -114,4 +114,4 @@ the FSD project structure inside the `src` folder. You should still also add the
 - [(Thread) About the pages directory in NextJS](https://t.me/feature_sliced/3623)
 
 [project-knowledge]: /docs/about/understanding/knowledge-types
-[ext-app-router-stackblitz]: https://stackblitz.com/edit/stackblitz-starters-aiez55?file=README.md 
+[ext-app-router-stackblitz]: https://stackblitz.com/edit/stackblitz-starters-aiez55?file=README.md


### PR DESCRIPTION
## Background

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->

Closes #714 


## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->

1. Fix the typo that said "app" instead of "pages" in the Next.js guide (en)


<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
