### PR TITLE
Move the feedback button to the bottom

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -31,3 +31,8 @@ h6 {
         border-radius: var(--ifm-button-border-radius) !important;
     }
 }
+
+.theme-back-to-top-button {
+    // The PushFeedback button is positioned in the same place, so we need to move the "back to top" button higher
+    bottom: 3.5rem;
+}

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -34,5 +34,5 @@ h6 {
 
 .theme-back-to-top-button {
     // The PushFeedback button is positioned in the same place, so we need to move the "back to top" button higher
-    bottom: 3.5rem;
+    bottom: 3.5rem !important;
 }

--- a/src/features/feedback/doc/index.tsx
+++ b/src/features/feedback/doc/index.tsx
@@ -55,7 +55,7 @@ export function FeedbackWidget({ projectId }: { projectId: string }) {
                 rating-stars-placeholder={translate({
                     id: "features.feedback-doc.rating-stars-placeholder",
                 })}
-                button-position="center-right"
+                button-position="bottom-right"
                 button-style="dark"
                 modal-position="bottom-right"
                 custom-font="true"

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -20,7 +20,7 @@ export default function FooterWrapper(
             <BrowserOnly>
                 {() =>
                     typeof customFields.pushFeedbackProjectId === "string" &&
-                    window.location.hostname === new URL(url).hostname && (
+                    (window.location.hostname === new URL(url).hostname || true) && (
                         <FeedbackWidget
                             projectId={customFields.pushFeedbackProjectId}
                         />

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -20,7 +20,7 @@ export default function FooterWrapper(
             <BrowserOnly>
                 {() =>
                     typeof customFields.pushFeedbackProjectId === "string" &&
-                    (window.location.hostname === new URL(url).hostname || true) && (
+                    window.location.hostname === new URL(url).hostname && (
                         <FeedbackWidget
                             projectId={customFields.pushFeedbackProjectId}
                         />


### PR DESCRIPTION
## Background

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->

Someone left feedback saying that the current position of the feedback widget gets in the way of reading the docs on mobile. Let's try a different position.

## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->

1. Move the feedback bottom from center right to bottom right


<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
