### PR TITLE
Fix the broken featureslices.dev domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0] - 2023-10-01
 
 > **Note**  
-> This release note is retrospective, meaning that prior to this release, the Feature-Sliced Design project did not keep a changelog. Below is a summary of the most prominent recent changes, but there is no FSD v1. Prior to FSD, there has been a project called ["Feature Slices"](https://featureslices.dev/v1.0.html), and it is considered to be the v1 of FSD.
+> This release note is retrospective, meaning that prior to this release, the Feature-Sliced Design project did not keep a changelog. Below is a summary of the most prominent recent changes, but there is no FSD v1. Prior to FSD, there has been a project called ["Feature Slices"](https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md), and it is considered to be the v1 of FSD.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0] - 2023-10-01
 
 > **Note**  
-> This release note is retrospective, meaning that prior to this release, the Feature-Sliced Design project did not keep a changelog. Below is a summary of the most prominent recent changes, but there is no FSD v1. Prior to FSD, there has been a project called ["Feature Slices"](https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md), and it is considered to be the v1 of FSD.
+> This release note is retrospective, meaning that prior to this release, the Feature-Sliced Design project did not keep a changelog. Below is a summary of the most prominent recent changes, but there is no FSD v1. Prior to FSD, there has been a project called ["Feature Slices"](https://feature-sliced.github.io/featureslices.dev/v1.0.html), and it is considered to be the v1 of FSD.
 
 ### Deprecated
 

--- a/config/docusaurus/navbar.js
+++ b/config/docusaurus/navbar.js
@@ -37,11 +37,11 @@ const navbar = {
             dropdownActiveClassDisabled: true,
             dropdownItemsAfter: [
                 {
-                    to: "https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md",
+                    to: "https://feature-sliced.github.io/featureslices.dev/v1.0.html",
                     label: "v1.0",
                 },
                 {
-                    to: "https://github.com/feature-sliced/featureslices.dev/blob/master/v0.1.md",
+                    to: "https://feature-sliced.github.io/featureslices.dev/v0.1.html",
                     label: "v0.1",
                 },
                 {

--- a/config/docusaurus/navbar.js
+++ b/config/docusaurus/navbar.js
@@ -37,11 +37,11 @@ const navbar = {
             dropdownActiveClassDisabled: true,
             dropdownItemsAfter: [
                 {
-                    to: "https://featureslices.dev/v1.0.html",
+                    to: "https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md",
                     label: "v1.0",
                 },
                 {
-                    to: "https://featureslices.dev/v0.1.html",
+                    to: "https://github.com/feature-sliced/featureslices.dev/blob/master/v0.1.md",
                     label: "v0.1",
                 },
                 {

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/migration/from-v1.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/migration/from-v1.md
@@ -161,7 +161,7 @@ Now it is much easier to [observe the principle of low coupling][refs-low-coupli
 [refs-low-coupling]: /docs/reference/isolation/coupling-cohesion
 [refs-adaptability]: /docs/about/understanding/naming
 
-[ext-v1]: https://featureslices.dev/v1.0.html
+[ext-v1]: https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md
 [ext-tg-spb]: https://t.me/feature_slices
 [ext-fdd]: https://github.com/feature-sliced/documentation/tree/rc/feature-driven
 [ext-fdd-issues]: https://github.com/kof/feature-driven-architecture/issues

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/migration/from-v1.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/migration/from-v1.md
@@ -161,7 +161,7 @@ Now it is much easier to [observe the principle of low coupling][refs-low-coupli
 [refs-low-coupling]: /docs/reference/isolation/coupling-cohesion
 [refs-adaptability]: /docs/about/understanding/naming
 
-[ext-v1]: https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md
+[ext-v1]: https://feature-sliced.github.io/featureslices.dev/v1.0.html
 [ext-tg-spb]: https://t.me/feature_slices
 [ext-fdd]: https://github.com/feature-sliced/documentation/tree/rc/feature-driven
 [ext-fdd-issues]: https://github.com/kof/feature-driven-architecture/issues

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/migration/from-v1.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/migration/from-v1.md
@@ -160,7 +160,7 @@ sidebar_position: 4
 [refs-low-coupling]: /docs/reference/isolation/coupling-cohesion
 [refs-adaptability]: /docs/about/understanding/naming
 
-[ext-v1]: https://featureslices.dev/v1.0.html
+[ext-v1]: https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md
 [ext-tg-spb]: https://t.me/feature_slices
 [ext-fdd]: https://github.com/feature-sliced/documentation/tree/rc/feature-driven
 [ext-fdd-issues]: https://github.com/kof/feature-driven-architecture/issues

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/migration/from-v1.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/migration/from-v1.md
@@ -160,7 +160,7 @@ sidebar_position: 4
 [refs-low-coupling]: /docs/reference/isolation/coupling-cohesion
 [refs-adaptability]: /docs/about/understanding/naming
 
-[ext-v1]: https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md
+[ext-v1]: https://feature-sliced.github.io/featureslices.dev/v1.0.html
 [ext-tg-spb]: https://t.me/feature_slices
 [ext-fdd]: https://github.com/feature-sliced/documentation/tree/rc/feature-driven
 [ext-fdd-issues]: https://github.com/kof/feature-driven-architecture/issues

--- a/src/features/hero/index.tsx
+++ b/src/features/hero/index.tsx
@@ -31,7 +31,7 @@ export function Hero() {
                 <div className="margin-top--md">
                     <Link
                         className={styles.link}
-                        to="https://featureslices.dev/"
+                        to="https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md"
                     >
                         {translate({ id: "features.hero.previous" })}{" "}
                         (feature-slices@v1)

--- a/src/features/hero/index.tsx
+++ b/src/features/hero/index.tsx
@@ -31,7 +31,7 @@ export function Hero() {
                 <div className="margin-top--md">
                     <Link
                         className={styles.link}
-                        to="https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md"
+                        to="https://feature-sliced.github.io/featureslices.dev/v1.0.html"
                     >
                         {translate({ id: "features.hero.previous" })}{" "}
                         (feature-slices@v1)

--- a/src/pages/versions/index.tsx
+++ b/src/pages/versions/index.tsx
@@ -62,12 +62,12 @@ function Version() {
                     <Table>
                         <Table.Row
                             th="v1.0"
-                            href="https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md"
+                            href="https://feature-sliced.github.io/featureslices.dev/v1.0.html"
                             hrefTitle="Documentation"
                         />
                         <Table.Row
                             th="v0.1"
-                            href="https://github.com/feature-sliced/featureslices.dev/blob/master/v0.1.md"
+                            href="https://feature-sliced.github.io/featureslices.dev/v0.1.html"
                             hrefTitle="Documentation"
                         />
                     </Table>

--- a/src/pages/versions/index.tsx
+++ b/src/pages/versions/index.tsx
@@ -62,12 +62,12 @@ function Version() {
                     <Table>
                         <Table.Row
                             th="v1.0"
-                            href="https://featureslices.dev/v1.0.html"
+                            href="https://github.com/feature-sliced/featureslices.dev/blob/master/v1.0.md"
                             hrefTitle="Documentation"
                         />
                         <Table.Row
                             th="v0.1"
-                            href="https://featureslices.dev/v0.1.html"
+                            href="https://github.com/feature-sliced/featureslices.dev/blob/master/v0.1.md"
                             hrefTitle="Documentation"
                         />
                     </Table>


### PR DESCRIPTION
## Background

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->

The `featureslices.dev` domain no longer works, so we can just link to GitHub


## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->

1. Replace all references to featureslices.dev with links to GitHub


<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
