### PR TITLE
docs: guides page translated into Korean

### DIFF
--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/index.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/index.mdx
@@ -1,0 +1,49 @@
+---
+hide_table_of_contents: true
+pagination_prev: get-started/index
+---
+
+# 🎯 Guides
+
+<span class="badge badge--primary margin-bottom--md">PRACTICE-ORIENTED</span>
+
+<p class="summary">
+Feature-Sliced Design(FSD)의 적용을 위한 종합 가이드입니다. 구체적인 예시, 마이그레이션 전략, 그리고 FSD 레거시 코드에서 발생할 수 있는 문제점들을 다룹니다. FSD를 프로젝트에 도입하거나 기존 구조를 개선하고자 할 때 참고하기 좋은 리소스입니다.
+</p>
+
+## Main
+
+import NavCard from "@site/src/shared/ui/nav-card/tmpl.mdx"
+import { ToolOutlined, ImportOutlined, BugOutlined, FunctionOutlined } from "@ant-design/icons";
+
+<NavCard
+    title="Examples" 
+    description="인증, 타입 관리, 페이지 레이아웃 등 다양한 기능을 다루는 예제들"
+    to="/docs/guides/examples"
+    Icon={ToolOutlined}
+    tags={['Authentication', 'Types', 'Page layout']}
+/>
+<NavCard
+    title="Migration" 
+    description="기존 아키텍처 및 FSD v1에서 FSD v2로 전환하는 가이드"
+    to="/docs/guides/migration/from-v1"
+    Icon={ImportOutlined}
+    tags={['From custom architecture', 'From FSv1']}
+/>
+<NavCard
+    title="Tech" 
+    description="Next.js, React Query 등 다양한 프레임워크와 라이브러리와 함께 FSD를 사용하는 방법"
+    to="/docs/guides/tech/with-nextjs"
+    Icon={FunctionOutlined}
+/>
+
+<NavCard
+    title="Code Issues (Smells)" 
+    description="레거시 코드에서 발생하는 아키텍처 문제와 해결책"
+    to="/docs/guides/issues/desegmented"
+    Icon={BugOutlined}
+    tags={['Desegmented', 'Routing', "Cross-imports"]}
+/>
+
+
+

--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/index.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/index.mdx
@@ -8,7 +8,7 @@ pagination_prev: get-started/index
 <span class="badge badge--primary margin-bottom--md">PRACTICE-ORIENTED</span>
 
 <p class="summary">
-Feature-Sliced Design(FSD)의 적용을 위한 종합 가이드입니다. 구체적인 예시, 마이그레이션 전략, 그리고 FSD 레거시 코드에서 발생할 수 있는 문제점들을 다룹니다. FSD를 프로젝트에 도입하거나 기존 구조를 개선하고자 할 때 참고하기 좋은 리소스입니다.
+Feature-Sliced Design(FSD)의 적용을 위한 종합 가이드입니다. 구체적인 예시, 마이그레이션 전략, 그리고 FSD 코드에서 발견할 수 있는 흔한 설계상의 문제들을 다룹니다. FSD를 프로젝트에 도입하거나 기존 구조를 개선하고자 할 때 참고하기 좋은 리소스입니다.
 </p>
 
 ## Main
@@ -18,28 +18,29 @@ import { ToolOutlined, ImportOutlined, BugOutlined, FunctionOutlined } from "@an
 
 <NavCard
     title="Examples" 
-    description="인증, 타입 관리, 페이지 레이아웃 등 다양한 기능을 다루는 예제들"
+    description="방법론을 적용한 실제 예시"
     to="/docs/guides/examples"
     Icon={ToolOutlined}
     tags={['Authentication', 'Types', 'Page layout']}
 />
 <NavCard
     title="Migration" 
-    description="기존 아키텍처 및 FSD v1에서 FSD v2로 전환하는 가이드"
+    description="기존 아키텍처에서 마이그레이션 하기 위한 가이드"
     to="/docs/guides/migration/from-v1"
     Icon={ImportOutlined}
     tags={['From custom architecture', 'From FSv1']}
 />
 <NavCard
     title="Tech" 
-    description="Next.js, React Query 등 다양한 프레임워크와 라이브러리와 함께 FSD를 사용하는 방법"
+    description="프레임워크 및 라이브러리별 사용 가이드"
     to="/docs/guides/tech/with-nextjs"
     Icon={FunctionOutlined}
+    tags={['NextJS', 'NuxtJS', 'React Query', 'SvelteKit']}
 />
 
 <NavCard
     title="Code Issues (Smells)" 
-    description="레거시 코드에서 발생하는 아키텍처 문제와 해결책"
+    description="코드에서 발견할 수 있는 흔한 설계상의 문제"
     to="/docs/guides/issues/desegmented"
     Icon={BugOutlined}
     tags={['Desegmented', 'Routing', "Cross-imports"]}


### PR DESCRIPTION
## Background

I have translated the Guide page into Korean. 

If you think there are aspects that need improvement, please let me know, and I would be happy to make the adjustments. Thank you!

I have requested a Korean translation review from one reviewer in the FSD Discord Korean community to ensure that my Korean writing is well done. I would appreciate it if you could merge it after the review is completed.

## Changelog

![image](https://github.com/user-attachments/assets/a286a830-ef76-4c0c-9a98-a18cbc4a02b3)


<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
