### PR TITLE
fix: fix typos in the SvelteKit guides

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nuxtjs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nuxtjs.mdx
@@ -66,7 +66,7 @@ Thus, the file structure will look like this:
 │   │   │   │   ├── home-page.vue
 │   │   │   ├── index.ts
 ```
-Finally, let's add a root to the config:
+Finally, let's add a route to the config:
 
 ```ts title="app/router.config.ts"
 import type { RouterConfig } from '@nuxt/schema'
@@ -111,8 +111,8 @@ Now, you can create routes for pages within `app` and connect pages from `pages`
 
 For example, to add a `Home` page to your project, you need to do the following steps:
 - Add a page slice inside the `pages` layer
-- Add the corresponding root inside the `app` layer
-- Align the page from the slice with the root
+- Add the corresponding route inside the `app` layer
+- Connect the page from the slice with the route
 
 To create a page slice, let's use the [CLI](https://github.com/feature-sliced/cli):
 
@@ -126,7 +126,7 @@ Create a ``home-page.vue`` file inside the ui segment, access it using the Publi
 export { default as HomePage } from './ui/home-page';
 ```
 
-Create a root for this page inside the `app` layer:
+Create a route for this page inside the `app` layer:
 
 ```sh
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-sveltekit.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-sveltekit.mdx
@@ -44,10 +44,10 @@ Thus, your file structure should look like this:
 │   ├── app
 │   │   ├── index.html
 │   │   ├── routes
-│   ├── pages                               # Папка pages, закреплённая за FSD
+│   ├── pages                               # FSD Pages folder
 ```
 
-Now, you can create roots for pages within `app` and connect pages from `pages` to them.
+Now, you can create routes for pages within `app` and connect pages from `pages` to them.
 
 For example, to add a home page to your project, you need to do the following steps:
 - Add a page slice inside the `pages` layer
@@ -60,13 +60,13 @@ To create a page slice, let's use the [CLI](https://github.com/feature-sliced/cl
 fsd pages home
 ```
 
-Create a ``home-page.vue`` file inside the ui segment, access it using the Public API
+Create a ``home-page.svelte`` file inside the ui segment, access it using the Public API
 
 ```ts title="src/pages/home/index.ts"
-export { default as HomePage } from './ui/home-page';
+export { default as HomePage } from './ui/home-page.svelte';
 ```
 
-Create a root for this page inside the `app` layer:
+Create a route for this page inside the `app` layer:
 
 ```sh
 
@@ -82,7 +82,7 @@ Create a root for this page inside the `app` layer:
 │   │   │   ├── index.ts
 ```
 
-Add your page component inside the `index.svelte` file:
+Add your page component inside the `+page.svelte` file:
 
 ```html title="src/app/routes/+page.svelte"
 <script>

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/tech/with-sveltekit.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/tech/with-sveltekit.mdx
@@ -60,10 +60,10 @@ export default config;
 fsd pages home
 ```
 
-Создайте файл `home-page.vue` внутри сегмента ui, откройте к нему доступ с помощью Public API
+Создайте файл `home-page.svelte` внутри сегмента ui, откройте к нему доступ с помощью Public API
 
 ```ts title="src/pages/home/index.ts"
-export { default as HomePage } from './ui/home-page';
+export { default as HomePage } from './ui/home-page.svelte';
 ```
 
 Создайте роут для этой страницы внутри слоя `app`:
@@ -82,7 +82,7 @@ export { default as HomePage } from './ui/home-page';
 │   │   │   ├── index.ts
 ```
 
-Добавьте внутрь `index.svelte` файла компонент вашей страницы:
+Добавьте внутрь `+page.svelte` файла компонент вашей страницы:
 
 ```html title="src/app/routes/+page.svelte"
 <script>


### PR DESCRIPTION
## Background

<!-- 
  Briefly describe what problem this PR is solving. 
  If these changes were previously discussed in an issue or discussion,
  please, leave a reference to it 🔖.
  
  If there is a issue that your PR closes, just write "Closes #ISSUE_NUMBER" (e.g. Closes #42)
  That will automatically close that issue, once PR is merged.
  Please make sure to address all parts of the issue if you write that!
-->

Someone pointed them out in PushFeedback:

> 1. "home-page.vue" should be "home-page.svelte" 
> 2. "Create a root" should be "Create a route" 
> 3. "index.svelte" should be "+page.svelte"


## Changelog

<!-- 
  Briefly describe the proposed changes below. 
  Numbered lists work best. 
  If you add 📷 screenshots or 🎞️ screencasts, you'll be our hero.
-->

Fix the above typos and improve some phrasing a bit


<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
