### PR TITLE
docs: change usersAdapter to artistAdapter

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/examples/types.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/examples/types.md
@@ -305,7 +305,7 @@ export const slice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(fetchSong.fulfilled, (state, action) => {
       // And handle the same fetch result by inserting the artists here
-      usersAdapter.upsertMany(state, action.payload.users)
+      artistAdapter.upsertMany(state, action.payload.artists)
     })
   },
 })

--- a/i18n/ja/docusaurus-plugin-content-docs/current/guides/examples/types.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/guides/examples/types.md
@@ -309,7 +309,7 @@ export const slice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(fetchSong.fulfilled, (state, action) => {
       // ここでバックエンドからの同じレスポンスを処理し、ユーザーを追加します
-      usersAdapter.upsertMany(state, action.payload.users)
+      artistAdapter.upsertMany(state, action.payload.artists)
     })
   },
 })

--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/examples/types.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/examples/types.md
@@ -308,7 +308,7 @@ export const slice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(fetchSong.fulfilled, (state, action) => {
       // 같은 fetch 결과를 처리하며, 여기서 artists를 삽입합니다.
-      usersAdapter.upsertMany(state, action.payload.users)
+      artistAdapter.upsertMany(state, action.payload.artists)
     })
   },
 })

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/examples/types.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/examples/types.md
@@ -307,7 +307,7 @@ export const slice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(fetchSong.fulfilled, (state, action) => {
       // И здесь обрабатываем тот же ответ с бэкенда, добавляя исполнителей
-      usersAdapter.upsertMany(state, action.payload.users)
+      artistAdapter.upsertMany(state, action.payload.users)
     })
   },
 })

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/examples/types.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/examples/types.md
@@ -307,7 +307,7 @@ export const slice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(fetchSong.fulfilled, (state, action) => {
       // И здесь обрабатываем тот же ответ с бэкенда, добавляя исполнителей
-      artistAdapter.upsertMany(state, action.payload.users)
+      artistAdapter.upsertMany(state, action.payload.artists)
     })
   },
 })


### PR DESCRIPTION
## Background

Just fixes typo in code example by replacing usersAdapter to artistAdapter
Documentation page:
https://feature-sliced.design/docs/guides/examples/types#how-to-deal-with-nested-dtos


## Changelog

Here, usersAdapter is undefined and probably just wrong. So artistAdapter must be used
<img width="879" alt="image" src="https://github.com/user-attachments/assets/401f3aa7-642d-4539-a173-2ba0e73adfa0">

