### PR TITLE
docs: translate code smells documentation pages into korean

### DIFF
--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/_category_.yaml
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/_category_.yaml
@@ -1,0 +1,2 @@
+label: Code smells & Issues
+position: 4

--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/cross-imports.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/cross-imports.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_position: 4
+sidebar_class_name: sidebar-item--wip
+pagination_next: reference/index
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# 크로스 임포트
+
+<WIP ticket="220" />
+
+> 크로스 임포트는 계층이나 추상화가 본래 맡아야 할 책임 이상의 역할을 수행하려 할 때 발생합니다. 이를 방지하기 위해, 방법론은 이러한 크로스 임포트를 해소할 수 있도록 별도의 계층을 정의합니다.
+
+## 참고 자료
+
+- [(스레드) 크로스 임포트가 불가피한 경우에 대한 논의](https://t.me/feature_sliced/4515)
+- [(스레드) 엔티티에서 크로스 임포트를 해결하는 방법](https://t.me/feature_sliced/3678)
+- [(스레드) 크로스 임포트와 책임의 관계에 대한 논의](https://t.me/feature_sliced/3287)
+- [(스레드) 세그먼트 간 임포트 문제를 다룬 논의](https://t.me/feature_sliced/4021)
+- [(스레드) 공유된 내부 구조에서 크로스 임포트를 해결하는 방법에 대한 논의](https://t.me/feature_sliced/3618)

--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/cross-imports.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/cross-imports.mdx
@@ -10,12 +10,12 @@ import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
 
 <WIP ticket="220" />
 
-> 크로스 임포트는 계층이나 추상화가 본래 맡아야 할 책임 이상의 역할을 수행하려 할 때 발생합니다. 이를 방지하기 위해, 방법론은 이러한 크로스 임포트를 해소할 수 있도록 별도의 계층을 정의합니다.
+> Cross-import는 Layer나 추상화가 원래의 책임 범위를 넘어설 때 발생합니다. 방법론에서는 이러한 Cross-import를 해결하기 위한 별도의 Layer를 정의합니다.
 
 ## 참고 자료
 
-- [(스레드) 크로스 임포트가 불가피한 경우에 대한 논의](https://t.me/feature_sliced/4515)
-- [(스레드) 엔티티에서 크로스 임포트를 해결하는 방법](https://t.me/feature_sliced/3678)
-- [(스레드) 크로스 임포트와 책임의 관계에 대한 논의](https://t.me/feature_sliced/3287)
-- [(스레드) 세그먼트 간 임포트 문제를 다룬 논의](https://t.me/feature_sliced/4021)
-- [(스레드) 공유된 내부 구조에서 크로스 임포트를 해결하는 방법에 대한 논의](https://t.me/feature_sliced/3618)
+- [(스레드) Cross-import가 불가피한 상황 논의](https://t.me/feature_sliced/4515)
+- [(스레드) Entity에서 Cross-import 해결 방법](https://t.me/feature_sliced/3678)
+- [(스레드) Cross-import와 책임 범위 관계](https://t.me/feature_sliced/3287)
+- [(스레드) Segment 간 import 이슈 해결](https://t.me/feature_sliced/4021)
+- [(스레드) Shared 내부 구조의 Cross-import 해결](https://t.me/feature_sliced/3618)

--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/desegmented.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/desegmented.mdx
@@ -5,13 +5,13 @@ sidebar_class_name: sidebar-item--wip
 
 import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
 
-# 비분절화
+# Desegmentation
 
 <WIP ticket="148" />
 
 ## 상황
 
-프로젝트에서는 특정 도메인과 관련된 모듈들이 서로 관련이 있음에도 불구하고, 불필요하게 분산되어 프로젝트 전체에 흩어져 있는 경우가 자주 발생합니다.
+프로젝트에서 동일한 도메인의 모듈들이 서로 연관되어 있음에도 불구하고, 프로젝트 전체에 불필요하게 분산되어 있는 경우가 많습니다.
 
 ```sh
 ├── components/
@@ -45,22 +45,22 @@ import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
 
 ## 문제점
 
-이 문제는 최소한 높은 응집성 원칙의 위반과, **변경 축의 과도한 확장(Stretching of the Axis of Changes)** 이라는 형태로 나타납니다.
+이는 높은 응집도 원칙을 위반하며, **Changes Axis의 과도한 확장**을 초래합니다.
 
-## 이를 무시할 경우
+## 무시했을 때의 결과
 
-- 예를 들어, 배송(delivery)과 관련된 로직을 수정하려면 여러 위치에 흩어져 있는 코드를 찾아 수정해야 합니다. 이는 변경이 필요한 범위를 불필요하게 넓혀 **변경 축을 확장** 시키는 결과를 초래합니다.
-- 사용자와 관련된 로직을 이해하려면, 프로젝트 전반에 흩어져 있는 **actions, epics, constants, entities, components** 를 모두 찾아 학습해야 합니다. 이는 이들이 한 곳에 모여 있지 않기 때문입니다.
-- 암묵적인 연결로 인해 도메인 영역이 비대해지며 통제하기 어려워질 수 있습니다.
-- 또한, 이 방식은 프로젝트 디렉토리에 "상수를 위한 상수 생성"과 같은 불필요한 파일을 무분별하게 쌓게 만들어, 문제를 제대로 인지하지 못하게 만듭니다.
+- delivery 관련 로직 수정 시 여러 위치의 코드를 찾아 수정해야 하며, 이는 **Changes Axis를 불필요하게 확장**합니다
+- user 관련 로직을 이해하려면 프로젝트 전반의 **actions, epics, constants, entities, components**를 모두 찾아봐야 합니다
+- 암묵적 연결로 인해 도메인 영역이 비대해지고 관리가 어려워집니다
+- 불필요한 파일들이 쌓여 문제 인식이 어려워집니다
 
-## 해결책
+## 해결 방안
 
-특정 도메인 또는 사용자 케이스와 관련된 모든 모듈을 서로 인접하게 배치합니다.
+도메인이나 use case와 관련된 모듈들을 한 곳에 모아 배치합니다.
 
-이를 통해 특정 모듈을 학습하거나 수정할 때 필요한 모든 구성 요소가 한곳에 모여 있어, 프로젝트 전체를 뒤질 필요가 없습니다.
+이를 통해 모듈 학습이나 수정 시 필요한 모든 요소를 쉽게 찾을 수 있습니다.
 
-> 이러한 접근 방식은 코드베이스의 탐색성과 명확성을 크게 향상시키며, 모듈 간의 관계를 더 직관적으로 이해할 수 있도록 돕습니다.
+> 이 접근은 코드베이스의 탐색성과 가독성을 높이고, 모듈 간 관계를 더 명확하게 보여줍니다.
 
 ```diff
 - ├── components/
@@ -91,7 +91,7 @@ import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
   |    ├── user/
 ```
 
-## See also
+## 참고 자료
 
-* [(아티클) 낮은 결합도와 높은 응집도에 대한 명확한 설명](https://enterprisecraftsmanship.com/posts/cohesion-coupling-difference/)
-* [(아티클) 낮은 결합도와 높은 응집도, 그리고 디미터의 법칙](https://medium.com/german-gorelkin/low-coupling-high-cohesion-d36369fb1be9)
+* [(아티클) Coupling과 Cohesion의 명확한 이해](https://enterprisecraftsmanship.com/posts/cohesion-coupling-difference/)
+* [(아티클) Coupling, Cohesion과 Law of Demeter](https://medium.com/german-gorelkin/low-coupling-high-cohesion-d36369fb1be9)

--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/desegmented.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/desegmented.mdx
@@ -1,0 +1,97 @@
+---
+sidebar_position: 2
+sidebar_class_name: sidebar-item--wip
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# 비분절화
+
+<WIP ticket="148" />
+
+## 상황
+
+프로젝트에서는 특정 도메인과 관련된 모듈들이 서로 관련이 있음에도 불구하고, 불필요하게 분산되어 프로젝트 전체에 흩어져 있는 경우가 자주 발생합니다.
+
+```sh
+├── components/
+|    ├── DeliveryCard
+|    ├── DeliveryChoice
+|    ├── RegionSelect
+|    ├── UserAvatar
+├── actions/
+|    ├── delivery.js
+|    ├── region.js
+|    ├── user.js
+├── epics/
+|    ├── delivery.js
+|    ├── region.js
+|    ├── user.js
+├── constants/
+|    ├── delivery.js
+|    ├── region.js
+|    ├── user.js
+├── helpers/
+|    ├── delivery.js
+|    ├── region.js
+|    ├── user.js
+├── entities/
+|    ├── delivery/
+|    |      ├── getters.js
+|    |      ├── selectors.js
+|    ├── region/
+|    ├── user/
+```
+
+## 문제점
+
+이 문제는 최소한 높은 응집성 원칙의 위반과, **변경 축의 과도한 확장(Stretching of the Axis of Changes)** 이라는 형태로 나타납니다.
+
+## 이를 무시할 경우
+
+- 예를 들어, 배송(delivery)과 관련된 로직을 수정하려면 여러 위치에 흩어져 있는 코드를 찾아 수정해야 합니다. 이는 변경이 필요한 범위를 불필요하게 넓혀 **변경 축을 확장** 시키는 결과를 초래합니다.
+- 사용자와 관련된 로직을 이해하려면, 프로젝트 전반에 흩어져 있는 **actions, epics, constants, entities, components** 를 모두 찾아 학습해야 합니다. 이는 이들이 한 곳에 모여 있지 않기 때문입니다.
+- 암묵적인 연결로 인해 도메인 영역이 비대해지며 통제하기 어려워질 수 있습니다.
+- 또한, 이 방식은 프로젝트 디렉토리에 "상수를 위한 상수 생성"과 같은 불필요한 파일을 무분별하게 쌓게 만들어, 문제를 제대로 인지하지 못하게 만듭니다.
+
+## 해결책
+
+특정 도메인 또는 사용자 케이스와 관련된 모든 모듈을 서로 인접하게 배치합니다.
+
+이를 통해 특정 모듈을 학습하거나 수정할 때 필요한 모든 구성 요소가 한곳에 모여 있어, 프로젝트 전체를 뒤질 필요가 없습니다.
+
+> 이러한 접근 방식은 코드베이스의 탐색성과 명확성을 크게 향상시키며, 모듈 간의 관계를 더 직관적으로 이해할 수 있도록 돕습니다.
+
+```diff
+- ├── components/
+- |    ├── DeliveryCard
+- |    ├── DeliveryChoice
+- |    ├── RegionSelect
+- |    ├── UserAvatar
+- ├── actions/
+- |    ├── delivery.js
+- |    ├── region.js
+- |    ├── user.js
+- ├── epics/{...}
+- ├── constants/{...}
+- ├── helpers/{...}
+  ├── entities/
+  |    ├── delivery/
++ |    |      ├── ui/ # ~ components/
++ |    |      |   ├── card.js
++ |    |      |   ├── choice.js
++ |    |      ├── model/
++ |    |      |   ├── actions.js
++ |    |      |   ├── constants.js
++ |    |      |   ├── epics.js
++ |    |      |   ├── getters.js
++ |    |      |   ├── selectors.js
++ |    |      ├── lib/ # ~ helpers
+  |    ├── region/
+  |    ├── user/
+```
+
+## See also
+
+* [(아티클) 낮은 결합도와 높은 응집도에 대한 명확한 설명](https://enterprisecraftsmanship.com/posts/cohesion-coupling-difference/)
+* [(아티클) 낮은 결합도와 높은 응집도, 그리고 디미터의 법칙](https://medium.com/german-gorelkin/low-coupling-high-cohesion-d36369fb1be9)

--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/routes.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/routes.mdx
@@ -1,18 +1,18 @@
 ---
 sidebar_position: 3
 sidebar_class_name: sidebar-item--wip
-sidebar_label: 라우팅
+sidebar_label: Routing
 ---
     
 import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
     
-# 라우팅
+# Routing
     
 <WIP ticket="169" />
     
 ## 상황
     
-페이지에 대한 URL이 페이지 아래 계층에 하드코딩되어 있는 경우가 발생합니다.
+Page의 URL이 하위 Layer에 하드코딩되어 있는 경우가 있습니다.
     
 ```tsx title="entities/post/card" 
 <Card>
@@ -26,21 +26,21 @@ import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
 
 ## 문제점
 
-URL이 책임 범위에 따라 페이지 계층에 집중되지 않고, 하위 계층에 분산되어 관리됩니다.
+URL이 Page Layer에 집중되지 않고, 하위 Layer에 분산되어 관리됩니다.
 
-## 무시할 경우
+## 무시했을 때의 결과
 
-URL을 변경하려면, 해당 URL(또는 URL과 관련된 리디렉션 로직)이 페이지 계층 외의 여러 하위 계층에 존재할 수 있음을 고려해야 합니다.
+URL 변경 시 Page Layer 외의 여러 하위 Layer에 있는 URL과 redirect 로직을 모두 고려해야 합니다.
 
-결과적으로, 단순한 상품 카드와 같은 요소조차 페이지의 책임 일부를 떠안게 되어, 프로젝트 전반의 로직이 불필요하게 복잡해질 수 있습니다.
+결과적으로 단순한 Product Card 같은 Component도 Page의 책임을 가지게 되어, 프로젝트 구조가 불필요하게 복잡해집니다.
 
-## 해결책
+## 해결 방안
 
-URL과 리디렉션 로직은 페이지 레벨과 그 위 계층에서만 처리하도록 결정합니다.
+URL과 redirect 로직은 Page Layer와 그 상위 Layer에서만 다루도록 합니다.
 
-이를 위해, 조립(composition), props 전달, 팩토리 패턴 등을 활용해 URL 정보를 하위 계층에 전달합니다.
+이를 위해 composition, props 전달, Factory 패턴 등을 활용해 URL 정보를 하위 Layer에 전달합니다.
 
 ## 참고 자료
 
-- [(스레드) 엔티티/피처/위젯에서 라우팅을 "봉합"하면 어떻게 될까요?](https://t.me/feature_sliced/4389)
-- [(스레드) 왜 라우트 로직을 페이지에만 섞으면 안 되는가?](https://t.me/feature_sliced/3756)
+- [(스레드) Entity/Feature/Widget에서 Routing 처리의 영향](https://t.me/feature_sliced/4389)
+- [(스레드) Page에서만 Route 로직을 다뤄야 하는 이유](https://t.me/feature_sliced/3756)

--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/routes.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/routes.mdx
@@ -1,0 +1,46 @@
+---
+sidebar_position: 3
+sidebar_class_name: sidebar-item--wip
+sidebar_label: 라우팅
+---
+    
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+    
+# 라우팅
+    
+<WIP ticket="169" />
+    
+## 상황
+    
+페이지에 대한 URL이 페이지 아래 계층에 하드코딩되어 있는 경우가 발생합니다.
+    
+```tsx title="entities/post/card" 
+<Card>
+    <Card.Title 
+        href={`/post/${data.id}`}
+        title={data.name}
+    />
+    ...
+</Card>
+```
+
+## 문제점
+
+URL이 책임 범위에 따라 페이지 계층에 집중되지 않고, 하위 계층에 분산되어 관리됩니다.
+
+## 무시할 경우
+
+URL을 변경하려면, 해당 URL(또는 URL과 관련된 리디렉션 로직)이 페이지 계층 외의 여러 하위 계층에 존재할 수 있음을 고려해야 합니다.
+
+결과적으로, 단순한 상품 카드와 같은 요소조차 페이지의 책임 일부를 떠안게 되어, 프로젝트 전반의 로직이 불필요하게 복잡해질 수 있습니다.
+
+## 해결책
+
+URL과 리디렉션 로직은 페이지 레벨과 그 위 계층에서만 처리하도록 결정합니다.
+
+이를 위해, 조립(composition), props 전달, 팩토리 패턴 등을 활용해 URL 정보를 하위 계층에 전달합니다.
+
+## 참고 자료
+
+- [(스레드) 엔티티/피처/위젯에서 라우팅을 "봉합"하면 어떻게 될까요?](https://t.me/feature_sliced/4389)
+- [(스레드) 왜 라우트 로직을 페이지에만 섞으면 안 되는가?](https://t.me/feature_sliced/3756)


### PR DESCRIPTION
## Background

We translated the cross-imports page, the desegmented page, and the routes page.

If you think there are aspects that need improvement, please let me know, and I would be happy to make the adjustments. Thank you!

I have requested a Korean translation review from one reviewer in the FSD Discord Korean community to ensure that my Korean writing is well done. I would appreciate it if you could merge it after the review is completed.