### PR TITLE
fix: update copyright year 2025 in advance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2023 Feature-Sliced Design core-team
+Copyright (c) 2018-2025 Feature-Sliced Design core-team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -60,7 +60,7 @@
         "description": "The label of footer link with label=GitHub linking to https://github.com/feature-sliced"
     },
     "copyright": {
-        "message": "Copyright © 2018-2023  Feature-Sliced Design",
+        "message": "Copyright © 2018-2025  Feature-Sliced Design",
         "description": "The footer copyright"
     }
 }

--- a/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/i18n/ja/docusaurus-theme-classic/footer.json
@@ -60,7 +60,7 @@
         "description": "The label of footer link with label=GitHub linking to https://github.com/feature-sliced"
     },
     "copyright": {
-        "message": "Copyright © 2018-2024  Feature-Sliced Design",
+        "message": "Copyright © 2018-2025  Feature-Sliced Design",
         "description": "The footer copyright"
     }
 }

--- a/i18n/ru/docusaurus-theme-classic/footer.json
+++ b/i18n/ru/docusaurus-theme-classic/footer.json
@@ -60,7 +60,7 @@
         "description": "The label of footer link with label=GitHub linking to https://github.com/feature-sliced"
     },
     "copyright": {
-        "message": "Copyright © 2018-2023  Feature-Sliced Design",
+        "message": "Copyright © 2018-2025  Feature-Sliced Design",
         "description": "The footer copyright"
     }
 }

--- a/i18n/uz/docusaurus-theme-classic/footer.json
+++ b/i18n/uz/docusaurus-theme-classic/footer.json
@@ -60,7 +60,7 @@
         "description": "The label of footer link with label=GitHub linking to https://github.com/feature-sliced"
     },
     "copyright": {
-        "message": "Copyright © 2018-2023  Feature-Sliced Design",
+        "message": "Copyright © 2018-2025  Feature-Sliced Design",
         "description": "The footer copyright"
     }
 }


### PR DESCRIPTION
## Background
I noticed several pages/translations have different copyright years.
I've crate PR which could help in 2025.
