### PR TITLE
docs: fsd app replaced with fsd pages in en comments

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
@@ -102,7 +102,7 @@ the FSD project structure inside the `src` folder. You should still also add the
 │   ├── app            # FSD app folder
 │   ├── entities
 │   ├── features
-│   ├── pages          # FSD app folder
+│   ├── pages          # FSD pages folder
 │   ├── shared
 │   ├── widgets
 ```


### PR DESCRIPTION
## Background
Noticed a small issue on the page - https://feature-sliced.design/docs/guides/tech/with-nextjs#app-router, where the `pages` layer is confused with `app` in the comments.
![image](https://github.com/user-attachments/assets/6b7b3b50-f458-49e1-b7f9-692e60b2fc98)

## Changelog
Adjusted comment on the page - replaced `FSD app folder` with `FSD pages folder` for `pages` layer