### PR TITLE
docs: Update Korean title to English in Cross-imports guide

### DIFF
--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/cross-imports.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/issues/cross-imports.mdx
@@ -6,7 +6,7 @@ pagination_next: reference/index
 
 import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
 
-# 크로스 임포트
+# Cross-import
 
 <WIP ticket="220" />
 


### PR DESCRIPTION
## Background

Updated the guide title to use "Cross-import" instead of the Korean term for better clarity and understanding. The English term "Cross-import" is more widely recognized and better represents the technical concept being discussed.


