### PR TITLE
Add translation for overview page to Uzbek language

### DIFF
--- a/i18n/uz/docusaurus-plugin-content-docs/current/get-started/overview.mdx
+++ b/i18n/uz/docusaurus-plugin-content-docs/current/get-started/overview.mdx
@@ -26,7 +26,6 @@ Bu yerda FSD qo'llanilgan oddiy loyiha:
 - `📁 pages`
 - `📁 shared`
 
-These top-level folders are called _layers_. Let's look deeper:
 Bu yuqori darajadagi papkalar ular _layers_ deyiladi. Keling chuqurroq qaraymiz:
 
 - `📂 app`

--- a/i18n/uz/docusaurus-plugin-content-docs/current/get-started/overview.mdx
+++ b/i18n/uz/docusaurus-plugin-content-docs/current/get-started/overview.mdx
@@ -1,0 +1,144 @@
+---
+sidebar_position: 1
+---
+
+# Qisqacha
+
+**Feature-Sliced Design** (FSD) bu front-end ilovalarining tuzilishini shakllantirish uchun arxitektura metodologiyasi. Oddiy qilib aytganda, bu kodni tartibga solish uchun qoidalar va konvensiyalar to'plami. Bu metodologiyaning asosiy maqsadi - loyihani yanada tushunarli va o'zgaruvchan biznes talablariga barqaror qilishdir.
+
+FSD nafaqat konvensiyalar to'plami balki vositalar to'plami hamdir. Bizda [linter][ext-steiger] sizning loyihangizning arxitekturasini tekshirish uchun, [papka generatorlari][ext-tools] CLI yoki IDE lar orqali, shuningdek, ko'plab [misollar][examples] jamlanmasiga ega.
+
+## Menga to'g'ri keladimi? {#is-it-right-for-me}
+
+FSD jamoalar qanday o'lchamda bo'lmasin uni amalga oshirish mumkin. Sizga to'g'ri keladi agar:
+
+- Siz **frontend** qilayotgan bo'lsangiz (UI webda, mobil, kompyuter/noutbuk(desktop), vhkz.)
+- Siz **ilova** qurayotgan bo'lsangiz, kutubxona emas
+
+Shunday! Bu yerda qaysi dasturlash tili, UI framework, yoki holat boshqaruvchisini ishlatish bo'yicha hech qanday cheklov yo'q. Shuningdek, FSD ni bosqichma-bosqich joriy qilishingiz, monorepolarda ishlatishingiz va ilovangizni modullarga bo'lib, FSD ni ularning har birida alohida amalga oshirishngiz mumkin.
+
+Agar sizda allaqachon arxitektura mavjud bo‘lsa va FSDga o‘tishni o‘ylayotgan bo‘lsangiz, avvalo joriy arxitektura jamoangizga muammo tug‘dirayotganiga ishonch hosil qiling. Masalan, agar loyihangiz juda katta va o‘zaro juda bog‘lanib ketgan bo‘lsa, bu yangi xususiyatlarni samarali joriy etishni qiyinlashtirishi mumkin. Yoki jamoangizga ko‘plab yangi a’zolar qo‘shilishi kutilayotgan bo‘lsa, FSDga o‘tish foydali bo‘lishi mumkin. Agar hozirgi arxitektura yaxshi ishlayotgan bo‘lsa, ehtimol uni o‘zgartirishga hojat yo‘q. Ammo agar migratsiya qilishga qaror qilsangiz, yo‘riqnoma uchun [Migratsiya][migration] sahifasini ko'rib chiqishingiz mumkin.
+## Asosiy misollar {#basic-example}
+
+Bu yerda FSD qo'llanilgan oddiy loyiha:
+
+- `📁 app`
+- `📁 pages`
+- `📁 shared`
+
+These top-level folders are called _layers_. Let's look deeper:
+Bu yuqori darajadagi papkalar ular _layers_ deyiladi. Keling chuqurroq qaraymiz:
+
+- `📂 app`
+   - `📁 routes`
+   - `📁 analytics`
+- `📂 pages`
+   - `📁 home`
+   - `📂 article-reader`
+      - `📁 ui`
+      - `📁 api`
+   - `📁 settings`
+- `📂 shared`
+   - `📁 ui`
+   - `📁 api`
+
+`📂 pages` ichidagi papkalar _slices_ deyiladi. Ular layer ni domenlar bo'yicha bo'lishadi(bu holatda, sahifalar bo'yicha) 
+
+`📂 app`, `📂 shared`, va `📂 pages/article-reader` ichidagilar _segments_ deyiladi, va ular slices(yoki layers), ya'ni kodning vazifasiga qarab ajratiladi.
+
+## Tushunchalar {#concepts}
+
+Layers, slices, and segments form a hierarchy like this:
+Layerlar, slicelar va segmentlar quyidagi ierarxiyani hosil qiladi:
+
+<figure>
+   ![Hierarchy of FSD concepts, described below](/img/visual_schema.jpg)
+
+   <figcaption style={{ fontStyle: "italic", fontSize: "0.9em" }}>
+      <p>Tepadagi rasmda: uchta ustunlar, chapdan o'ngga qarab mos ravishda "Layerlar", "Slicelar" va "Segmentlar" deb belgilangan.</p>
+      <p>"Layerlar" ustuni yuqoridan pastga qarab joylashtirilgan etti bo‘limni o‘z ichiga oladi: "app", "processes", "pages", "widgets", "features", "entities" va "shared". "Processes" bo‘limi ustidan chizib tashlangan. "Entities" bo‘limi ikkinchi ustun — "Slicelar" bilan bog‘langan bo‘lib, bu ikkinchi ustunning "entities" tarkibida ekanligini bildiradi.</p>
+      <p>"Slicelar" ustuni yuqoridan pastga qarab joylashtirilgan uch bo‘limni o‘z ichiga oladi: "user", "post" va "comment". "Post" bo‘limi uchinchi ustun — "Segmentlar" bilan bog‘langan bo‘lib, bu uchinchi ustunning "post" tarkibida ekanligini bildiradi.</p>
+      <p>"Segments" ustuni yuqoridan pastga qarab joylashtirilgan uchta bo'limni o'z ichiga oladi: "ui", "model" va "api".</p>
+   </figcaption>
+</figure>
+
+### Layers {#layers}
+
+Layerlar barcha FSD loyihalarida standartlashtirilgan. Siz ularning barchasidan foydalanishingiz shart emas, lekin ularning nomlari muhim. Hozirda yettita layer mavjud(tepadan pastga qarab):
+
+1. **App** — Ilovaning ishlashi uchun zarur bo'lgan hamma narsa — marshrutlash(routing), dastur boshlanish nuqtasi(entrypoint), global stillar, provayderlar.
+2. **Processes** (eskirgan) — Murakkab sahifalararo ssenariylar(ya'ni foydalanuvchi bir sahifada amal bajarsa, boshqa sahifada natija ko‘rinishi yoki turli sahifalar o‘rtasida holat (state) uzatilishi).
+3. **Pages** — To‘liq sahifalar yoki ichma-ich marshrutlashdagi(routing) sahifaning katta qismlari.
+4. **Widgets** — Katta, mustaqil funksionallik yoki UI bo‘laklari, odatda butun bir foydalanish holatini ta’minlaydi.
+5. **Features** — _Qayta foydalaniladigan_ butun mahsulot xususiyatlarining implementatsiyalari, ya’ni foydalanuvchiga biznes qiymatini keltiradigan harakatlar.
+6. **Entities** — Loyihada ishlaydigan biznes obyekti, masalan, `user` yoki `product`.
+7. **Shared** — Loyihaning yoki biznesning aniq xususiyatlariga bog‘liq bo‘lmagan, lekin qayta ishlatiladigan funksionallik.
+
+:::warning
+
+**App** va **Shared** layerlari boshqa layerlardan farqli o‘laroq slices ga ega emas va to‘g‘ridan-to‘g‘ri segments ga bo‘linadi.
+
+Biroq, boshqa barcha layerlar — **Entities**, **Features**, **Widgets** va **Pages** avval slices yaratishni talab qiladi, shundan keyingina ularning ichida segments yaratiladi.
+
+:::
+Layerlar bilan ishlashning asosiy tamoyili shundaki, bitta layerdagi modullar faqat o‘zidan quyi joylashgan layerlardagi modullarni bilishi va ulardan import qilishi mumkin.
+
+### Slices {#slices}
+
+Keyingi tushuncha slices, ya’ni kodni biznes domenlari bo‘yicha bo‘lish usuli. Ularning nomlarini o‘zingiz tanlashingiz va xohlaganingizcha ko‘paytirishingiz mumkin. Slices kod bazangizni yanada tushunarli qiladi, chunki bir-biriga bog‘liq modullar bir joyda saqlanadi.
+
+Slices bir xil layer ichida boshqa slicelardan foydalana olmaydi. Bu esa yuqori bir butunlik (cohesion) va past bog‘liqlik (low coupling) tamoyillariga rioya qilishga yordam beradi.
+
+### Segments {#segments}
+
+Slices, shuningdek, App va Shared layerlari segmentlardan tashkil topadi. Segmentlar kodni uning maqsadiga qarab guruhlaydi. Segment nomlari standart bilan cheklanmagan, ammo eng keng tarqalgan maqsadlar uchun bir nechta an’anaviy nomlar mavjud:
+
+- `ui` — UI ni aks ettiruvchi barcha narsalar: UI komponentlar, sana formatlagichlar, stillar va boshqalar.
+- `api` — backend bilan munosabat: so'rov funksiyalari, ma'lumot turlari, mapperlar va boshqalar.
+- `model` — ma'lumot modeli: sxemalar, interfeyslar, holat saqlovchi obyektlar (stores) va biznes mantiq(business logic).
+- `lib` — Ushbu sliceda joylashgan boshqa modullarga kerak kutubxona kodi.
+- `config` — configuration files and feature flags.konfiguratsiya fayllari va yoqib o'chiriladigan xususiyat bayroqlari(feature flags)
+
+Odatda, ushbu segmentlar ko‘pchilik layerlar uchun yetarli bo‘ladi. Siz faqat Shared yoki App layerlarida o‘z segmentlaringizni yaratishingiz mumkin, lekin bu qat’iy qoida emas.
+
+## Afzalliklar {#advantages}
+
+- **Bir xillik**  
+  Tuzilma standartlashtirilganligi sababli loyihalar yanada bir xil ko'rinishga ega bo‘ladi, bu esa jamoaga yangi a’zolarni jalb qilish jarayonini osonlashtiradi.
+
+- **O'zgarishlar va refaktoring jarayonida barqarorlik**  
+  Bitta layerdagi modul boshqa shu layerdagi yoki undan yuqoridagi modullardan foydalana olmaydi.   
+  Bu esa ilovaning boshqa qismlariga kutilmagan ta’sir ko‘rsatmasdan izolyatsiyalangan o‘zgarishlar kiritish imkonini beradi.
+
+- **Qayta foydalaniladigan mantiq(logic) ni tartibli boshqarish**  
+  Layerga qarab, kodni keng miqyosda qayta ishlatish yoki faqat ma'lum bir joyda ishlatish mumkin.  
+  Bu esa **DRY** tamoyilini ushlab turish bilan birga, loyihaning qulayligini ham saqlab qolishga yordam beradi.
+
+- **Biznes va foydalanuvchi ehtiyojlariga yo‘naltirilganlik.**  
+  Ilova biznes domenlarga bo‘lingan va nomlashda biznesga oid terminologiya(business language) dan foydalanish tavsiya etiladi, bu esa sizga loyiha tarkibidagi boshqa qismlarni to‘liq tushunmasdan ham mahsulot ustida ishlash imkonini beradi.
+
+## Bosqichma-bosqich joriy etish {#incremental-adoption}
+
+Agar mavjud kod bazangizni FSD ga o'tkazmoqchi bo'lsangiz, quyidagi strategiyani tavsiya qilamiz. Bu buni bizning tajribamizda foydali deb topdik.
+
+1. Avval App va Shared layerlarini modul-ma-modul shakllantirib, mustahkam asos yarating.
+
+2. Mavjud UI komponentlarini Widgets va Pages ga umumiy tartibda joylashtiring, hatto ular FSD qoidalarini buzadigan bog‘liqliklarga ega bo‘lsa ham.
+
+3. Import qoidabuzarliklarini bosqichma-bosqich tuzatishni boshlang va shu bilan birga Entities, ehtimol Features ham ajratib chiqing.
+
+Refaktoring jarayonida yoki loyihaning faqat ayrim qismlarini o‘zgartirayotganda yangi yirik Entities qo‘shmaslik tavsiya etiladi.
+
+## Keyingi qadamlar {#next-steps}
+
+- **FSD haqida chuqur tushuncha hosil qilmoqchimisiz?** [Bu yerda][tutorial].
+- **Misollar bilan o'rganishni afzal ko'rasizmi?** Bizda juda ko'plab [Misollar][examples] bo'limi mavjud.
+- **Savolingiz bormi?** Bizning [Telegram chat][ext-telegram] ga qo'shiling va yordam oling.
+
+[tutorial]: /docs/get-started/tutorial
+[examples]: /examples
+[migration]: /docs/guides/migration/from-custom
+[ext-steiger]: https://github.com/feature-sliced/steiger
+[ext-tools]: https://github.com/feature-sliced/awesome?tab=readme-ov-file#tools
+[ext-telegram]: https://t.me/feature_sliced
+

--- a/i18n/uz/docusaurus-plugin-content-docs/current/get-started/overview.mdx
+++ b/i18n/uz/docusaurus-plugin-content-docs/current/get-started/overview.mdx
@@ -4,18 +4,18 @@ sidebar_position: 1
 
 # Qisqacha
 
-**Feature-Sliced Design** (FSD) bu front-end ilovalarining tuzilishini shakllantirish uchun arxitektura metodologiyasi. Oddiy qilib aytganda, bu kodni tartibga solish uchun qoidalar va konvensiyalar to'plami. Bu metodologiyaning asosiy maqsadi - loyihani yanada tushunarli va o'zgaruvchan biznes talablariga barqaror qilishdir.
+**Feature-Sliced Design** (FSD) bu front-end ilovalarining tuzilishini shakllantirish uchun arxitektura metodologiyasi. Oddiy qilib aytganda, bu kodni tartibga solish uchun qoidalar va konvensiyalar to'plami. Bu metodologiyaning asosiy maqsadi - loyihani yanada tushunarli va o'zgaruvchan biznes talablariga moslashuvchan qilishdir.
 
-FSD nafaqat konvensiyalar to'plami balki vositalar to'plami hamdir. Bizda [linter][ext-steiger] sizning loyihangizning arxitekturasini tekshirish uchun, [papka generatorlari][ext-tools] CLI yoki IDE lar orqali, shuningdek, ko'plab [misollar][examples] jamlanmasiga ega.
+FSD nafaqat konvensiyalar to'plami, balki vositalar to'plamini ham o'z ichiga oladi. Bizda [linter][ext-steiger] sizning loyihangizning arxitekturasini tekshirish uchun, [papka generatorlari][ext-tools] CLI yoki IDE lar orqali, shuningdek, ko'plab [misollar][examples] jamlanmasiga ega.
 
 ## Menga to'g'ri keladimi? {#is-it-right-for-me}
 
-FSD jamoalar qanday o'lchamda bo'lmasin uni amalga oshirish mumkin. Sizga to'g'ri keladi agar:
+FSD har qanday hajmdagi jamoalarda joriy qilinishi mumkin. Sizga to'g'ri keladi agar:
 
-- Siz **frontend** qilayotgan bo'lsangiz (UI webda, mobil, kompyuter/noutbuk(desktop), vhkz.)
+- Siz **frontend** qilayotgan bo'lsangiz (veb, mobil, kompyuter dasturlari, h.k.)
 - Siz **ilova** qurayotgan bo'lsangiz, kutubxona emas
 
-Shunday! Bu yerda qaysi dasturlash tili, UI framework, yoki holat boshqaruvchisini ishlatish bo'yicha hech qanday cheklov yo'q. Shuningdek, FSD ni bosqichma-bosqich joriy qilishingiz, monorepolarda ishlatishingiz va ilovangizni modullarga bo'lib, FSD ni ularning har birida alohida amalga oshirishngiz mumkin.
+Shu bilan birga, bu yerda qaysi dasturlash tili, UI(foydalanuvchi interfeysi) freymvorki, yoki holat boshqaruvchisi(state manager)ni ishlatish bo'yicha hech qanday cheklov yo'q. Shuningdek, FSD ni bosqichma-bosqich joriy qilishingiz, monorepo(yagona repozitoriya)larda ishlatishingiz va ilovangizni modullarga bo'lib, FSD ni ularning har birida alohida amalga oshirishingiz mumkin.
 
 Agar sizda allaqachon arxitektura mavjud bo‘lsa va FSDga o‘tishni o‘ylayotgan bo‘lsangiz, avvalo joriy arxitektura jamoangizga muammo tug‘dirayotganiga ishonch hosil qiling. Masalan, agar loyihangiz juda katta va o‘zaro juda bog‘lanib ketgan bo‘lsa, bu yangi xususiyatlarni samarali joriy etishni qiyinlashtirishi mumkin. Yoki jamoangizga ko‘plab yangi a’zolar qo‘shilishi kutilayotgan bo‘lsa, FSDga o‘tish foydali bo‘lishi mumkin. Agar hozirgi arxitektura yaxshi ishlayotgan bo‘lsa, ehtimol uni o‘zgartirishga hojat yo‘q. Ammo agar migratsiya qilishga qaror qilsangiz, yo‘riqnoma uchun [Migratsiya][migration] sahifasini ko'rib chiqishingiz mumkin.
 ## Asosiy misollar {#basic-example}
@@ -26,7 +26,7 @@ Bu yerda FSD qo'llanilgan oddiy loyiha:
 - `📁 pages`
 - `📁 shared`
 
-Bu yuqori darajadagi papkalar ular _layers_ deyiladi. Keling chuqurroq qaraymiz:
+Bu yuqori darajadagi papkalar ular _layerlar_ deyiladi. Keling chuqurroq qaraymiz:
 
 - `📂 app`
    - `📁 routes`
@@ -41,32 +41,31 @@ Bu yuqori darajadagi papkalar ular _layers_ deyiladi. Keling chuqurroq qaraymiz:
    - `📁 ui`
    - `📁 api`
 
-`📂 pages` ichidagi papkalar _slices_ deyiladi. Ular layer ni domenlar bo'yicha bo'lishadi(bu holatda, sahifalar bo'yicha) 
+`📂 pages` ichidagi papkalar _slice(bo'lak)lar_ deyiladi. Ular layer ni domenlar bo'yicha bo'lishadi(bu holatda, sahifalar bo'yicha) 
 
-`📂 app`, `📂 shared`, va `📂 pages/article-reader` ichidagilar _segments_ deyiladi, va ular slices(yoki layers), ya'ni kodning vazifasiga qarab ajratiladi.
+`📂 app`, `📂 shared`, va `📂 pages/article-reader` ichidagilar _segment(bo'lim)lar_ deyiladi, va ular slicelar(yoki layerlar), ya'ni kodning vazifasiga qarab ajratiladi.
 
 ## Tushunchalar {#concepts}
 
-Layers, slices, and segments form a hierarchy like this:
-Layerlar, slicelar va segmentlar quyidagi ierarxiyani hosil qiladi:
+Layerlar, slicelar va segmentlar quyidagi iyerarxiyani hosil qiladi:
 
 <figure>
-   ![Hierarchy of FSD concepts, described below](/img/visual_schema.jpg)
+   ![FSD konsepsiyalari iyearxiyasi, quyida tasvirlangan](/img/visual_schema.jpg)
 
    <figcaption style={{ fontStyle: "italic", fontSize: "0.9em" }}>
       <p>Tepadagi rasmda: uchta ustunlar, chapdan o'ngga qarab mos ravishda "Layerlar", "Slicelar" va "Segmentlar" deb belgilangan.</p>
-      <p>"Layerlar" ustuni yuqoridan pastga qarab joylashtirilgan etti bo‘limni o‘z ichiga oladi: "app", "processes", "pages", "widgets", "features", "entities" va "shared". "Processes" bo‘limi ustidan chizib tashlangan. "Entities" bo‘limi ikkinchi ustun — "Slicelar" bilan bog‘langan bo‘lib, bu ikkinchi ustunning "entities" tarkibida ekanligini bildiradi.</p>
-      <p>"Slicelar" ustuni yuqoridan pastga qarab joylashtirilgan uch bo‘limni o‘z ichiga oladi: "user", "post" va "comment". "Post" bo‘limi uchinchi ustun — "Segmentlar" bilan bog‘langan bo‘lib, bu uchinchi ustunning "post" tarkibida ekanligini bildiradi.</p>
+      <p>"Layers" ustuni yuqoridan pastga qarab joylashtirilgan etti bo‘limni o‘z ichiga oladi: "app", "processes", "pages", "widgets", "features", "entities" va "shared". "Processes" bo‘limi ustidan chizib tashlangan. "Entities" bo‘limi ikkinchi ustun — "Slicelar" bilan bog‘langan bo‘lib, bu ikkinchi ustunning "entities" tarkibida ekanligini bildiradi.</p>
+      <p>"Slices" ustuni yuqoridan pastga qarab joylashtirilgan uch bo‘limni o‘z ichiga oladi: "user", "post" va "comment". "Post" bo‘limi uchinchi ustun — "Segmentlar" bilan bog‘langan bo‘lib, bu uchinchi ustunning "post" tarkibida ekanligini bildiradi.</p>
       <p>"Segments" ustuni yuqoridan pastga qarab joylashtirilgan uchta bo'limni o'z ichiga oladi: "ui", "model" va "api".</p>
    </figcaption>
 </figure>
 
-### Layers {#layers}
+### Layerlar {#layers}
 
 Layerlar barcha FSD loyihalarida standartlashtirilgan. Siz ularning barchasidan foydalanishingiz shart emas, lekin ularning nomlari muhim. Hozirda yettita layer mavjud(tepadan pastga qarab):
 
 1. **App** — Ilovaning ishlashi uchun zarur bo'lgan hamma narsa — marshrutlash(routing), dastur boshlanish nuqtasi(entrypoint), global stillar, provayderlar.
-2. **Processes** (eskirgan) — Murakkab sahifalararo ssenariylar(ya'ni foydalanuvchi bir sahifada amal bajarsa, boshqa sahifada natija ko‘rinishi yoki turli sahifalar o‘rtasida holat (state) uzatilishi).
+2. **Processes** (eskirgan) — Murakkab sahifalararo ssenariylar(ya'ni foydalanuvchi bir sahifada amal bajarsa, boshqa sahifada natija ko‘rinishi yoki turli sahifalar o‘rtasida state(holat) uzatilishi).
 3. **Pages** — To‘liq sahifalar yoki ichma-ich marshrutlashdagi(routing) sahifaning katta qismlari.
 4. **Widgets** — Katta, mustaqil funksionallik yoki UI bo‘laklari, odatda butun bir foydalanish holatini ta’minlaydi.
 5. **Features** — _Qayta foydalaniladigan_ butun mahsulot xususiyatlarining implementatsiyalari, ya’ni foydalanuvchiga biznes qiymatini keltiradigan harakatlar.
@@ -75,28 +74,28 @@ Layerlar barcha FSD loyihalarida standartlashtirilgan. Siz ularning barchasidan 
 
 :::warning
 
-**App** va **Shared** layerlari boshqa layerlardan farqli o‘laroq slices ga ega emas va to‘g‘ridan-to‘g‘ri segments ga bo‘linadi.
+**App** va **Shared** layerlari boshqa layerlardan farqli o‘laroq slicelarga ega emas va to‘g‘ridan-to‘g‘ri segmentlarga bo‘linadi.
 
-Biroq, boshqa barcha layerlar — **Entities**, **Features**, **Widgets** va **Pages** avval slices yaratishni talab qiladi, shundan keyingina ularning ichida segments yaratiladi.
+Biroq, boshqa barcha layerlar — **Entities**, **Features**, **Widgets** va **Pages** avval slicelar yaratishni talab qiladi, shundan keyingina ularning ichida segments yaratiladi.
 
 :::
 Layerlar bilan ishlashning asosiy tamoyili shundaki, bitta layerdagi modullar faqat o‘zidan quyi joylashgan layerlardagi modullarni bilishi va ulardan import qilishi mumkin.
 
-### Slices {#slices}
+### Slicelar {#slices}
 
-Keyingi tushuncha slices, ya’ni kodni biznes domenlari bo‘yicha bo‘lish usuli. Ularning nomlarini o‘zingiz tanlashingiz va xohlaganingizcha ko‘paytirishingiz mumkin. Slices kod bazangizni yanada tushunarli qiladi, chunki bir-biriga bog‘liq modullar bir joyda saqlanadi.
+Keyingi tushuncha slicelar, ya’ni kodni biznes domenlari bo‘yicha bo‘lish usuli. Ularning nomlarini o‘zingiz tanlashingiz va xohlaganingizcha ko‘paytirishingiz mumkin. Slices kod bazangizni yanada tushunarli qiladi, chunki bir-biriga bog‘liq modullar bir joyda saqlanadi.
 
-Slices bir xil layer ichida boshqa slicelardan foydalana olmaydi. Bu esa yuqori bir butunlik (cohesion) va past bog‘liqlik (low coupling) tamoyillariga rioya qilishga yordam beradi.
+Slicelar bir xil layer ichida boshqa slicelardan foydalana olmaydi. Bu esa yuqori cohesion([uyg'unlik][cohesion]) va low coupling([past bog‘liqlik][low-coupling]) tamoyillariga rioya qilishga yordam beradi.
 
-### Segments {#segments}
+### Segmentlar {#segments}
 
-Slices, shuningdek, App va Shared layerlari segmentlardan tashkil topadi. Segmentlar kodni uning maqsadiga qarab guruhlaydi. Segment nomlari standart bilan cheklanmagan, ammo eng keng tarqalgan maqsadlar uchun bir nechta an’anaviy nomlar mavjud:
+Slicelar, shuningdek, App va Shared layerlari segmentlardan tashkil topadi. Segmentlar kodni uning maqsadiga qarab guruhlaydi. Segment nomlari standart bilan cheklanmagan, ammo eng keng tarqalgan maqsadlar uchun bir nechta an’anaviy nomlar mavjud:
 
-- `ui` — UI ni aks ettiruvchi barcha narsalar: UI komponentlar, sana formatlagichlar, stillar va boshqalar.
+- `ui` — UI(foydalanuvchi interfeysi) ni aks ettiruvchi barcha narsalar: UI(foydalanuvchi interfeysi) komponentlar, sana formatlagichlar, stillar va boshqalar.
 - `api` — backend bilan munosabat: so'rov funksiyalari, ma'lumot turlari, mapperlar va boshqalar.
 - `model` — ma'lumot modeli: sxemalar, interfeyslar, holat saqlovchi obyektlar (stores) va biznes mantiq(business logic).
 - `lib` — Ushbu sliceda joylashgan boshqa modullarga kerak kutubxona kodi.
-- `config` — configuration files and feature flags.konfiguratsiya fayllari va yoqib o'chiriladigan xususiyat bayroqlari(feature flags)
+- `config` — konfiguratsiya fayllari va feature flags(yoqib o'chiriladigan xususiyat bayroqlari)
 
 Odatda, ushbu segmentlar ko‘pchilik layerlar uchun yetarli bo‘ladi. Siz faqat Shared yoki App layerlarida o‘z segmentlaringizni yaratishingiz mumkin, lekin bu qat’iy qoida emas.
 
@@ -105,11 +104,11 @@ Odatda, ushbu segmentlar ko‘pchilik layerlar uchun yetarli bo‘ladi. Siz faqa
 - **Bir xillik**  
   Tuzilma standartlashtirilganligi sababli loyihalar yanada bir xil ko'rinishga ega bo‘ladi, bu esa jamoaga yangi a’zolarni jalb qilish jarayonini osonlashtiradi.
 
-- **O'zgarishlar va refaktoring jarayonida barqarorlik**  
+- **O'zgarishlar va refaktoring(kodni qayta tuzish) jarayonida barqarorlik**  
   Bitta layerdagi modul boshqa shu layerdagi yoki undan yuqoridagi modullardan foydalana olmaydi.   
   Bu esa ilovaning boshqa qismlariga kutilmagan ta’sir ko‘rsatmasdan izolyatsiyalangan o‘zgarishlar kiritish imkonini beradi.
 
-- **Qayta foydalaniladigan mantiq(logic) ni tartibli boshqarish**  
+- **Qayta foydalaniladigan mantiq(logic)ni tartibli boshqarish**  
   Layerga qarab, kodni keng miqyosda qayta ishlatish yoki faqat ma'lum bir joyda ishlatish mumkin.  
   Bu esa **DRY** tamoyilini ushlab turish bilan birga, loyihaning qulayligini ham saqlab qolishga yordam beradi.
 
@@ -118,7 +117,7 @@ Odatda, ushbu segmentlar ko‘pchilik layerlar uchun yetarli bo‘ladi. Siz faqa
 
 ## Bosqichma-bosqich joriy etish {#incremental-adoption}
 
-Agar mavjud kod bazangizni FSD ga o'tkazmoqchi bo'lsangiz, quyidagi strategiyani tavsiya qilamiz. Bu buni bizning tajribamizda foydali deb topdik.
+Agar mavjud kod bazangizni FSD ga o'tkazmoqchi bo'lsangiz, quyidagi strategiyani tavsiya qilamiz. Biz buni bizning tajribamizda foydali deb topdik.
 
 1. Avval App va Shared layerlarini modul-ma-modul shakllantirib, mustahkam asos yarating.
 
@@ -140,4 +139,6 @@ Refaktoring jarayonida yoki loyihaning faqat ayrim qismlarini o‘zgartirayotgan
 [ext-steiger]: https://github.com/feature-sliced/steiger
 [ext-tools]: https://github.com/feature-sliced/awesome?tab=readme-ov-file#tools
 [ext-telegram]: https://t.me/feature_sliced
+[low-coupling]: https://en.wikipedia.org/wiki/Loose_coupling
+[cohesion]: https://en.wikipedia.org/wiki/Cohesion_(computer_science)
 


### PR DESCRIPTION
## Background
This PR adds the Uzbek language translation for the overview page. I'm a new contributor, and I'm still learning, so there might be some mistakes in my changes. Please feel free to point them out!

There is no related issue for this change.

## Changelog
1. Added translation for the overview page to Uzbek language.

