### PR TITLE
docs: add middleware section to NextJS guide in English and Russian

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
@@ -109,6 +109,10 @@ the FSD project structure inside the `src` folder. You should still also add the
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)][ext-app-router-stackblitz]
 
+## Middleware
+
+If you are using middleware in a project, it also needs to be moved from `src` to the root of the project. Otherwise, NextJS simply won't see it — middleware must be located strictly at the root next to `app` or `pages'.
+
 ## See also {#see-also}
 
 - [(Thread) About the pages directory in NextJS](https://t.me/feature_sliced/3623)

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
@@ -111,7 +111,7 @@ the FSD project structure inside the `src` folder. You should still also add the
 
 ## Middleware
 
-If you are using middleware in a project, it also needs to be moved from `src` to the root of the project. Otherwise, NextJS simply won't see it — middleware must be located strictly at the root next to `app` or `pages'.
+If you are using middleware in a project, it also needs to be moved from `src` to the root of the project. Otherwise, NextJS simply won't see it — middleware must be located strictly at the root next to `app` or `pages`.
 
 ## See also {#see-also}
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
@@ -106,7 +106,12 @@ App Router стал стабильным в NextJS версии 13.4. App Router
 │   ├── widgets
 ```
 
+
 [![Открыть в StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)][ext-app-router-stackblitz]
+
+## Middleware
+
+Если вы используете middleware в проекте, его также нужно переместить из `src` в корень проекта. Иначе NextJS просто не увидит его — middleware должен находиться строго в корне рядом с `app` или `pages`.
 
 ## См. также {#see-also}
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
@@ -106,7 +106,6 @@ App Router стал стабильным в NextJS версии 13.4. App Router
 │   ├── widgets
 ```
 
-
 [![Открыть в StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)][ext-app-router-stackblitz]
 
 ## Middleware
@@ -118,4 +117,4 @@ App Router стал стабильным в NextJS версии 13.4. App Router
 - [(Тред) Про pages директорию в NextJS](https://t.me/feature_sliced/3623)
 
 [project-knowledge]: /docs/about/understanding/knowledge-types
-[ext-app-router-stackblitz]: https://stackblitz.com/edit/stackblitz-starters-aiez55?file=README.md 
+[ext-app-router-stackblitz]: https://stackblitz.com/edit/stackblitz-starters-aiez55?file=README.md


### PR DESCRIPTION
Updated the documentation for NextJS. Added an explanation about the need to place the `middleware` file in the root directory of the project.