### PR TITLE
Fixed: typo in public-api documentation

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/reference/public-api.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/reference/public-api.md
@@ -79,7 +79,7 @@ Circular import is when two or more files import each other in a circle.
 
 These situations are often difficult for bundlers to deal with, and in some cases they might even lead to runtime errors that might be difficult to debug.
 
-Circular imports can occur without index files, but having an index file presents a clear opporutnity to accidentally create a circular import. It often happens when you have two objects exposed in the public API of a slice, for example, `HomePage` and `loadUserStatistics`, and the `HomePage` needs to access `loadUserStatistics`, but it does it like this:
+Circular imports can occur without index files, but having an index file presents a clear opportunity to accidentally create a circular import. It often happens when you have two objects exposed in the public API of a slice, for example, `HomePage` and `loadUserStatistics`, and the `HomePage` needs to access `loadUserStatistics`, but it does it like this:
 
 ```jsx title="pages/home/ui/HomePage.jsx"
 import { loadUserStatistics } from "../"; // importing from pages/home/index.js


### PR DESCRIPTION
## Changelog

Fixed a typo:  opporutnity -> opportunity.
