### PR TITLE
docs(ko): refine FAQ page for brevity & clarity

### DIFF
--- a/i18n/kr/docusaurus-plugin-content-docs/current/get-started/faq.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/get-started/faq.md
@@ -6,58 +6,56 @@ pagination_next: guides/index
 # FAQ
 
 :::info
-
-여러분은 [Telegram chat][telegram], [Discord community][discord] 그리고 [GitHub Discussions][github-discussions]에서 질문을 할 수 있습니다.
-
+질문은 언제든 [Telegram][telegram], [Discord][discord], [GitHub Discussions][github-discussions]에서 남겨 주세요.
 :::
 
-### toolkit이나 linter가 있나요?
+### Toolkit이나 Linter가 있나요?
 
-네! 우리는 CLI 또는 IDE를 통해 프로젝트의 아키텍처와 [폴더 생성기][ext-tools]를 확인하기 위한 [Steiger][ext-steiger]라는 linter를 가지고 있습니다.
+프로젝트 아키텍처를 FSD 규칙에 맞게 검사 [Steiger][ext-steiger] Linter가 있으며, CLI · IDE 확장을 통해 사용할 수 있는 [폴더 생성기][ext-tools]도 함께 제공됩니다.
 
-### Where to store the layout/template of pages?
+### Page Layout / Template은 어디에 보관해야 하나요?
 
-순수한 마크업 레이아웃이 필요하다면 `shared/ui`에 보관할 수 있습니다. 상위 계층을 사용해야 한다면 몇 가지 옵션이 있습니다.
+- **단순 마크업**이라면 `shared/ui`에 두는 것이 일반적입니다.  
+- 코드가 몇 줄뿐이라면 굳이 추상화하지 말고 각 페이지에 직접 작성해도 무방합니다.  
+- 복잡한 Layout이 필요하다면 별도 **Widget** 또는 **Page**로 분리하고 App Router(또는 Nested Routing)에서 조합하세요.
 
-- 레이아웃이 필요 없을 수도 있습니다. 레이아웃이 몇 줄밖에 안 된다면, 추상화하려고 하기보다는 각 페이지에서 코드를 중복하는 것이 합리적일 수 있습니다.
-- 레이아웃이 필요하다면, 별도의 위젯이나 페이지로 만들고 App의 라우터 설정에서 조합할 수 있습니다. 중첩 라우팅도 다른 옵션입니다.
+### Feature와 Entity의 차이는 무엇인가요?
 
-### feature와 entity의 차이점이 무엇인가요?
+| 구분 | 정의 | 예시 |
+| --- | --- | --- |
+| **Entity** | 애플리케이션이 다루는 **비즈니스 개체** | `user`, `product` |
+| **Feature** | 사용자가 Entity로 수행하는 **실제 상호작용** | 로그인, 장바구니 담기 |
 
-*entity*는 앱이 다루는 실제 개념입니다. *feature*는 앱 사용자에게 실제 가치를 제공하는 상호작용, 즉 사람들이 entity로 하고 싶어하는 것입니다.
+더 자세한 내용과 예시는 [Slices][reference-entities]에서 확인할 수 있습니다.
 
-더 자세한 정보와 예시는 [slices][reference-entities] 참조 페이지를 확인하세요.
+### Pages, Features, Entities를 서로 포함할 수 있나요?
 
-### pages/features/entities를 서로 포함시킬 수 있나요?
+가능합니다. 다만 **상위 Layer**에서만 조합해야 합니다.  
+예: Widget 내부에서 여러 Feature를 props / children 형태로 결합할 수 있지만, 한 Feature가 다른 Feature를 직접 import 하는 것은 [**Layer Import 규칙**][import-rule-layers]에 의해 금지됩니다.
 
-네, 하지만 이런 포함은 상위 계층에서 이루어져야 합니다. 예를 들어, 위젯 내부에서 여러 기능을 가져와서 하나의 기능을 다른 기능의 props/children으로 삽입할 수 있습니다.
+### Atomic Design을 함께 사용할 수 있나요?
 
-한 기능을 다른 기능에서 가져올 수는 없습니다. 이는 [**계층에 대한 가져오기 규칙**][import-rule-layers]에 의해 금지됩니다.
+네. FSD는 Atomic Design 사용을 **요구하지도, 금지하지도** 않습니다.  
+필요하다면 `ui` Segment 내부에서 Atomic 분류를 적용할 수 있습니다. [예시](https://t.me/feature_sliced/1653)
 
-### 아토믹 디자인은 어떤가요?
+### FSD 관련 참고 자료가 더 있나요?
 
-현재 버전의 방법론은 Feature-Sliced Design과 함께 아토믹 디자인을 사용하는 것을 요구하지도, 금지하지도 않습니다.
+커뮤니티가 정리한 자료 모음은 [feature‑sliced/awesome](https://github.com/feature-sliced/awesome)에서 확인할 수 있습니다.
 
-예를 들어, 아토믹 디자인은 모듈의 `ui` 세그먼트에 [잘 적용될 수 있습니다](https://t.me/feature_sliced/1653).
+### Feature‑Sliced Design이 필요한 이유는 무엇인가요?
 
-### FSD에 대한 유용한 리소스/기사 등이 있나요?
+표준화된 아키텍처는 프로젝트를 빠르게 파악하게 해 줍니다.  
+온보딩 속도를 높이고 “폴더 구조 논쟁”을 줄여 주는 것이 FSD의 핵심 가치입니다. 자세한 배경은 [Motivation][motivation] 페이지를 참고하세요.
 
-네! https://github.com/feature-sliced/awesome 를 참조하세요.
+### 주니어 개발자도 아키텍처 방법론이 필요할까요?
 
-### Feature-Sliced Design이 왜 필요한가요?
-
-프로젝트를 주요 가치 창출 구성 요소 측면에서 빠르게 개요를 파악하는 데 도움이 됩니다. 표준화된 아키텍처는 온보딩 속도를 높이고 코드 구조에 대한 논쟁을 해결합니다. FSD가 만들어진 이유에 대해 더 자세히 알아보려면 [동기][motivation] 페이지를 참조하세요.
-
-### 초보 개발자에게 아키텍처/방법론이 필요한가요?
-
-그렇다고 볼 수 있습니다.
-
-*보통 한 사람이 프로젝트를 설계하고 개발할 때는 모든 것이 순조롭게 진행됩니다. 하지만 개발에 중단이 있거나 새로운 개발자가 팀에 합류하면 문제가 발생합니다*
+필요합니다.  
+*혼자 개발할 때는 문제가 없어 보여도, 개발 공백이 생기거나 새로운 팀원이 합류하면 구조의 중요성이 드러납니다*
 
 
-### 인증 컨텍스트는 어떻게 다루나요?
+### 인증(Auth) Context는 어떻게 다루나요?
 
-[여기](/docs/guides/examples/auth)에서 답변했습니다.
+[예제 가이드](/docs/guides/examples/auth)에서 자세히 설명했습니다.
 
 [ext-steiger]: https://github.com/feature-sliced/steiger
 [ext-tools]: https://github.com/feature-sliced/awesome?tab=readme-ov-file#tools


### PR DESCRIPTION
## Background

The Korean FAQ page was wordy, contained meta‑phrases, and repeated ideas.  
Using our style checklist (concise sentences, no meta‑talk, clear subject, consistent terms), I rewrote the answers to read faster and added minor structural tweaks (info box, table, bullet lists).

- Rephrased all Q&A for brevity and active voice.
- Added a comparison table for **Feature vs Entity**.