### PR TITLE
docs(ko): rename “Get Started” → “시작하기” and polish nav‑card texts

### DIFF
--- a/i18n/kr/docusaurus-plugin-content-docs/current/get-started/index.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/get-started/index.mdx
@@ -31,3 +31,10 @@ FSD가 제공하는 주요 이점과 등장한 배경도 함께 살펴봅니다.
     to="/docs/get-started/faq"
     Icon={QuestionCircleOutlined}
 />
+
+{/* <NavCard
+    title="Decomposition cheatsheet"
+    description="A memo on the decomposition of logic with examples and criteria"
+    to="/docs/get-started/cheatsheet"
+    Icon={BuildOutlined}
+/> */}

--- a/i18n/kr/docusaurus-plugin-content-docs/current/get-started/index.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/get-started/index.mdx
@@ -6,33 +6,28 @@ pagination_prev: intro
 import { PlaySquareOutlined, QuestionCircleOutlined, RocketOutlined } from "@ant-design/icons";
 import NavCard from "@site/src/shared/ui/nav-card/tmpl.mdx";
 
-# 🚀 Get Started
+# 🚀 시작하기
 
 <p class="summary">
-환영합니다! 이 섹션은 Feature-Sliced Design의 적용과 방법론의 기본을 익히는 데 도움을 줍니다. 또한 이 방법론의 주요 장점과 그것이 만들어진 이유를 이해하게 될 것입니다.
+환영합니다! 이 섹션에서는 Feature‑Sliced Design(FSD)의 기본 개념과 실제 적용 방법을 빠르게 익힐 수 있습니다.<br/>
+FSD가 제공하는 주요 이점과 등장한 배경도 함께 살펴봅니다.
 </p>
 
 <NavCard
     title="개요"
-    description="방법론의 개념과 사용에 대한 간단한 개요"
+    description="FSD의 개념·구성·활용법을 한눈에 살펴봅니다."
     to="/docs/get-started/overview"
     Icon={RocketOutlined}
 />
 <NavCard
     title="튜토리얼"
-    description="FSD 사용에 대한 입문 튜토리얼"
+    description="단계별 실습으로 FSD를 직접 적용해 봅니다."
     to="/docs/get-started/tutorial"
     Icon={PlaySquareOutlined}
 />
 <NavCard
     title="FAQ"
-    description="자주 묻는 질문"
+    description="자주 묻는 질문으로 궁금증을 해결합니다."
     to="/docs/get-started/faq"
     Icon={QuestionCircleOutlined}
 />
-{/* <NavCard
-    title="Decomposition cheatsheet"
-    description="A memo on the decomposition of logic with examples and criteria"
-    to="/docs/get-started/cheatsheet"
-    Icon={BuildOutlined}
-/> */}


### PR DESCRIPTION
## Background

To keep the Korean docs fully localised, we changed the page header from “Get Started” to **“시작하기”** and rewrote the summary / NavCard descriptions for clearer, action‑oriented wording.  
Action‑verbs (“살펴봅니다”, “적용해 봅니다”, “해결합니다”) guide readers toward the next step and improve scan‑ability, especially for first‑time visitors.

## Changelog

- Rename page heading: `# 🚀 Get Started` → `# 🚀 시작하기`.
- Rephrased summary paragraph (shorter, highlights benefits and background).
- Updated NavCard descriptions:
  - Overview – “FSD’s concept, structure, usage at a glance.”
  - Tutorial – “Hands‑on steps to apply FSD.”
  - FAQ – “Answers to common questions.”
  - 