### PR TITLE
docs(ko): rewrite of Korean Type Guide — terminology cleanup & structural overhaul

### DIFF
--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/examples/types.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/examples/types.md
@@ -4,17 +4,17 @@ sidebar_position: 2
 
 # 타입
 
-이 가이드는 Typescript와 같은 정적 타입 언어의 데이터 타입을 다루는 방법과 FSD 구조 내에서 타입이 어떻게 활용되는지 설명합니다.
+이 가이드는 TypeScript 같은 정적 타입 언어에서 데이터를 정의·활용하는 방법과, FSD 구조 내에서 타입을 어디에 배치할지 설명합니다.
 
 :::info
 
-이 가이드에서 다루지 않는 질문이 있으신가요? 오른쪽 파란색 버튼을 눌러 피드백을 남겨주세요. 여러분의 의견을 반영해 가이드를 확장해 나가겠습니다! 
+더 궁금한 점이 있나요? 페이지 우측의 피드백 버튼을 눌러 의견을 남겨 주세요. 여러분의 제안은 문서 개선에 큰 도움이 됩니다!
 
 :::
 
 ## 유틸리티 타입 
 
-유틸리티 타입은 자체로 큰 의미를 가지지는 않지만, 다른 타입과 자주 사용되는 경우가 많은 타입입니다. 예를 들어, 배열의 값을 나타내는 ArrayValues 타입을 정의할 수 있습니다. 
+유틸리티 타입은 **스스로 큰 의미를 갖지는 않지만 다른 타입과 함께 자주 쓰이는 보조 타입**입니다. 예를 들어 배열 요소 타입을 추출하는 `ArrayValues`를 아래와 같이 정의할 수 있습니다.
 
 <figure>
 
@@ -28,9 +28,17 @@ type ArrayValues<T extends readonly unknown[]> = T[number];
 
 </figure>
 
-프로젝트에서 이러한 유틸리티 타입을 활용하려면, [`type-fest`][ext-type-fest] 같은 라이브러리를 설치하거나, 직접 `shared/lib`에 유틸리티 타입을 모아 라이브러리를 구축할 수 있습니다. 새로 추가할 타입과 이 라이브러리에 속하지 않는 타입을 명확하게 구분하는 것이 중요합니다. 예를 들어, 이를 `shared/lib/utility-types`로 수정하고 유틸리티 타입들에 대한 설명을 포함한 README 파일을 추가하는 것도 좋은 방법입니다. 
+프로젝트 전역에서 유틸리티 타입을 사용하려면 두 가지 방법이 있습니다.
 
-하지만 유틸리티 타입을 너무 많이 재사용하려고 하지 않는 것도 중요합니다. 재사용할 수 있다고 해서 꼭 모든 곳에서 사용할 필요는 없습니다. 모든 유틸리티 타입을 공유 폴더에 넣기보다는, 상황에 따라 필요한 파일 가까에에 두는 것이 더 좋을 떄도 있습니다. 
+1. **외부 라이브러리 설치**  
+   대표적으로 [`type-fest`](https://github.com/sindresorhus/type-fest)를 설치합니다.
+2. **내부 라이브러리 구축**  
+   `shared/lib/utility-types` 폴더를 만들고 README에 “우리 팀에서 유틸리티 타입이라 부르는 기준”과 “추가·제외 규칙”을 명확히 적어 둡니다.
+
+> 유틸리티 타입의 **재사용 가능성**을 지나친 기대를 하지 마세요.  
+> 재사용 가능하다고 해서 반드시 전역에 둘 필요는 없습니다.
+
+아래처럼 **사용 위치 근처**에 두는 편이 유지보수에 유리할 때가 많습니다.
 
 - 📂 pages
   - 📂 home
@@ -39,21 +47,21 @@ type ArrayValues<T extends readonly unknown[]> = T[number];
       - 📄 getMemoryUsageMetrics.ts (유틸리티 타입을 사용하는 코드)
 
 :::warning
-
-`shared/types` 폴더를 생성하거나 각 slice에 `types`라는 segment를 추가하고 싶은 마음이 들 수 있지만, 그렇게 하지 않는 것이 좋습니다.<br/>
-`types`라는 카테고리는 `components`나 `hooks`와 마찬가지로 내용이 무엇인지를 설명할 뿐, 코드의 목적을 명확히 설명하지 않습니다. slice는 해당 코드의 목적을 정확히 설명할 수 있어야 합니다.
-
+`shared/types` 폴더를 만들거나 각 slice에 `types` segment를 추가하고 싶을 수 있습니다.  
+그러나 **types 는 코드의 목적을 설명하지 못하는 분류**입니다.  
+segment와 폴더는 무엇을 담는지가 아니라 왜 존재하는지를 드러내야 합니다.
 :::
 
-## 비즈니스 entity 및 상호 참조 관계
+## 비즈니스 entity와 상호 참조
 
-앱에서 가장 중요한 타입 중 하나는 비즈니스 entity, 즉 앱에서 다루는 객체들 입니다. 
-예를 들어, 음악 스트리밍 앱에서는 _Song_, _Album_ 등이 비즈니스 entity가 될 수 있습니다. 
+앱에서 가장 핵심이 되는 타입은 **비즈니스 entity**—즉, 도메인 객체—입니다.  
+음악 스트리밍 서비스를 예로 들면 _Song_, _Album_ 등이 entity입니다.
 
-비즈니스 entity는 주로 백엔드 바탕이기 떄문에, 백엔드 응답을 타입으로 정의하는 것이 첫 번째 단계입니다. 
-각 endpoint에 대한 요청 함수와 그 응답을 타입으로 지정하는 것이 좋습니다, 추가적인 타입 안정성을 위해 [Zod][ext-zod]와 같은 스키마 검증 라이브러리를 사용해 응답을 검증할 수도 있습니다. 
 
-예를 들어, 모든 요청을 Shared에 보관하는 경우 이렇게 작성할 수 있습니다.
+### 1. 백엔드 Response 타입
+
+백엔드에서 내려오는 데이터를 먼저 타입으로 정의합니다.  
+추가적인 타입 안전성을 위해 [Zod][ext-zod] 같은 schema 기반 유효성 검사을 적용할 수도 있습니다.
 
 ```ts title="shared/api/songs.ts"
 import type { Artist } from "./artists";
@@ -69,14 +77,24 @@ export function listSongs() {
 }
 ```
 
-`Song` 타입은 다른 entity인 `Artist`를 참조합니다. 이와 같이 요청 관련 코드들을 Shared에 관리하면, 타입들의 서로 얽혀 있을 떄 관리가 용이해집니다. 만약 이 함수를 `entities/song/api`에 보관했다면, `entities/artist`에서 간단히 가져오는 것이 어려웠을 것 입니다. FSD 구조에서는 [layer별 import 규칙][import-rule-on-layers]을 통해 slice 간의 교차 import를 제한하고 있기 떄문입니다:
+`Song` 타입은 다른 entity인 `Artist`를 참조합니다.  
+**Request·Response 코드를 Shared에 두면** 이런 상호 참조를 한곳에서 관리할 수 있어 유지보수가 간편해집니다.
 
-> slice 안에 있는 module은 계층적으로 더 낮은 layer에 위치한 slice만 가져올 수 있습니다.
+반대로 이 함수를 `entities/song/api` 내부에 두면 다음과 같은 문제가 생깁니다.
 
-이 문제를 해결하기 위한 두 가지 방법은 다음과 같습니다:
+- `entities/artist` slice가 `Song`을 **가져오고 싶어도**  
+  FSD의 [layer별 import 규칙][import-rule-on-layers] 때문에 **동일 layer 간(import)** 의존은 금지됩니다.
+- 규칙 요약  
+  > *“한 slice의 모듈은 자신보다 **아래 layer**에 있는 slice만 import할 수 있다.”*
 
-1. **타입 매개변수화**  
-   타입이 다른 entity와 연결될 때, 타입 매개변수를 통해 처리할 수 있습니다. 예를 들어, Song 타입에 ArtistType이라는 제약 조건을 설정할 수 있습니다.
+즉, 동일 layer 간 cross-import가 막혀 있어 **Artist → Song** 의존을 직접 연결하기 어렵습니다.  
+이럴 땐 제네릭 파라미터화 또는 `@x` Public API 같은 방법을 선택해야 합니다.
+
+
+### 2. 상호 참조 해결 전략
+
+1. **제네릭 타입 매개변수화**  
+   entity 간 연결이 필요한 타입에는 제네릭 타입 매개변수를 선언하고, 필요한 제약 조건을 부여합니다. 예를 들어, Song 타입에 ArtistType이라는 제약 조건을 설정할 수 있습니다.
 
    ```ts title="entities/song/model/song.ts"
    interface Song<ArtistType extends { id: string }> {
@@ -86,17 +104,17 @@ export function listSongs() {
    }
    ```
 
-   이 방법은 일부 타입에 더 적합합니다. 예를 들어, `Cart = { items: Array<Product> }`처럼 간단한 타입은 다양한 제품 타입을 지원하기 쉽게 할 수 있습니다. 하지만 `Country`와 `City`처럼 더 밀접하게 연결된 타입은 분리하기 어렵습니다.
+   제네릭 방식은 `Cart = { items: Product[] }`처럼 단순한 타입과 잘 어울립니다. 반면 `Country‑City`처럼 긴밀히 결합된 구조는 분리하기 어렵습니다.
 
-2. **Cross-import (공개 API를 사용해 관리하기)**  
-    FSD에서 entity 간 cross-imports를 허용하기 위해서는 공개 API를 사용할 수 있습니다. 예를 들어, `song`, `artist`, `playlist`라는 entity가 있고, 후자의 두 entity가 `song`을 참조해야 한다고 가정합니다. 이 경우, `song` entity 내에 `artist`와 `playlist`용 공개 API를 따로 `@x` 표기를 만들어 사용할 수 있습니다.
+2. **Cross-import (Public API(@x) 활용)**  
+    FSD에서 entity 간 의존을 허용하려면, 참조 대상 entity 내부에 상대 entity 전용 Public API를 `@x` 디렉터리에 둡니다. 예를 들어 `artist`와 `playlist`가 `song`을 참조해야 한다면 다음과 같이 구성합니다.
 
    - 📂 entities
      - 📂 song
        - 📂 @x
-         - 📄 artist.ts (artist entities를 가져오기 위한 public API)
-         - 📄 playlist.ts (playlist.ts (playlist entities를 가져오기 위한 public API))
-       - 📄 index.ts (일반적인 public API)
+         - 📄 artist.ts (artist entity용 public API)
+         - 📄 playlist.ts (playlist entity용 public API)
+       - 📄 index.ts (기본 public API)
    
     파일 `📄 entities/song/@x/artist.ts`의 내용은 `📄 entities/song/index.ts`와 유사합니다: 
 
@@ -104,7 +122,7 @@ export function listSongs() {
    export type { Song } from "../model/song.ts";
    ```
 
-   따라서 `📄 entities/artist/model/artist.ts` 파일은 다음과 같이 `Song`을 가져올 수 있습니다:
+   이제 `📄 entities/artist/model/artist.ts`에서는 다음과 같이 `Song`을 가져옵니다.
 
    ```ts title="entities/artist/model/artist.ts"
    import type { Song } from "entities/song/@x/artist";
@@ -115,17 +133,18 @@ export function listSongs() {
    }
    ```
 
-   이렇게 entity 간 명시적으로 연결을 해두면 의존 관계를 파악하고 도메인 분리 수준을 유지하기 쉬워집니다. 
+   이렇게 명시적으로 연결하면 각 entity의 의존 관계를 쉽게 파악하고, 도메인 분리를 유지할 수 있습니다.
 
 ## 데이터 전송 객체와 mappers {#data-transfer-objects-and-mappers}
 
-데이터 전송 객체(Data Transfer Object, DTO)는 백엔드에서 오는 데이터의 구조를 나타내는 용어입니다. 떄로는 DTO를 그대로 사용하는 것이 편리할 수 있지만, 경우에 따라 프론트엔드에서는 불편할 수 있습니다. 이때 mapper를 사용해 DTO를 더 편리한 형태로 변환합니다. 
+데이터 전송 객체(Data Transfer Object, DTO)는 백엔드에서 전달되는 데이터 구조를 의미합니다. DTO를 그대로 써도 될 때가 있지만, 프론트엔드에서 쓰기엔 다소 불편합니다. 이때 `mapper`를 사용해 DTO를 더 다루기 쉬운 형태로 변환합니다.
 
-### DTO의 위치
+### DTO 배치 위치
 
-백엔드 타입이 별도의 패키지에 있는 경우(예: 프론트엔드와 백엔드에서 코드를 공유하는 경우) DTO를 해당 패키지에서 가져와 사용하면 됩니다. 백엔드와 프론트엔드 간 코드 공유가 없다면, 프론트엔드 코드베이스 어딘가에 DTO를 보관해야 하는데, 이를 아래에서 다루어 보겠습니다.
+- 백엔드 타입을 별도 패키지로 공유하는 경우 → 해당 패키지에서 DTO를 가져오면 끝입니다.
+- 코드 공유가 없는 경우 → 프론트엔드 코드베이스 어딘가에 DTO를 넣어야 합니다.
 
-`shared/api`에 요청 함수가 있다면, DTO 역시 해당 함수 바로 옆에 두는 것이 좋습니다:
+Request 함수가 `shared/api`에 있다면 DTO도 바로 옆에 두는 편이 좋습니다.
 
 ```ts title="shared/api/songs.ts"
 import type { ArtistDTO } from "./artists";
@@ -141,11 +160,9 @@ export function listSongs() {
 }
 ```
 
-앞에서 언급한 것처럼, 요청과 DTO를 shared에 두면 다른 DTO를 참조하기가 용이합니다.
+### mapper 배치 위치
 
-### Mappers의 위치
-
-Mapper는 DTO를 받아 변환하는 역할을 하므로, DTO 정의와 가까운 위치에 두는 것이 좋습니다. 만약 요청과 DTO가 `shared/api`에 정의되어 있다면, mapper도 그곳에 위치하는 것이 적절합니다.
+mapper는 DTO를 인자로 받아 변환하므로, DTO 정의와 최대한 가까이 둡니다. `shared/api`에 Request와 DTO가 있다면 mapper도 그곳에 둡니다.
 
 ```ts title="shared/api/songs.ts"
 import type { ArtistDTO } from "./artists";
@@ -160,7 +177,7 @@ interface SongDTO {
 interface Song {
   id: string;
   title: string;
-  /** 노래의 전체 제목, 디스크 번호까지 포함된 제목입니다. */
+  /** 디스크 번호까지 포함한 전체 제목 */
   fullTitle: string;
   artistIds: Array<string>;
 }
@@ -179,7 +196,7 @@ export function listSongs() {
 }
 ```
 
-요청과 상태 관리 코드가 entity slice에 정의되어 있는 경우, mapper 역시 해당 slice 내에 두는 것이 좋습니다. 이때 slice 간 교차 참조가 발생하지 않도록 주의해야 합니다.
+Request·Store가 `entity slice` 내부에 있다면 mapper도 해당 slice에 배치합니다(cross-import 제한 주의).
 
 ```ts title="entities/song/api/dto.ts"
 import type { ArtistDTO } from "entities/artist/@x/song";
@@ -241,9 +258,10 @@ const songsSlice = createSlice({
 });
 ```
 
-### 중첩된 DTO 처리 방법
+### 중첩 DTO 처리
 
-백엔드 응답에 여러 entity가 포함된 경우 문제가 될 수 있습니다. 예를 들어, 곡 정보에 저자의 ID뿐만 아니라 저자 객체 전체가 포함된 경우가 있을 수 있습니다. 이런 상황에서는 entity 간의 상호 참조를 피하기 어렵습니다. 데이터를 지우거나 백엔드 팀과 협의하지 않는 한, 이러한 경우에는 slice 간 간접적인 연결 대신 명시적인 교차 참조를 사용하는 것이 좋습니다. 이를 위해 `@x` 표기법을 활용할 수 있으며, 다음은 Redux Toolkit을 사용한 예시입니다:
+백엔드 Response 에 여러 entity가 포함되면 서로를 알지 않을 수 없습니다. 예를 들어 곡 정보에 저자 객체 전체가 포함될 수 있습니다. 
+이런 경우, 간접 연결(middleware 등) 대신 `@x` 표기법을 활용한 명시적 cross‑import가 낫습니다. 아래는 Redux Toolkit + Normalizr 예시입니다.
 
 ```ts title="entities/song/model/songs.ts"
 import {
@@ -256,7 +274,7 @@ import { normalize, schema } from 'normalizr'
 
 import { getSong } from "../api/getSong";
 
-// Normalizr의 entities 스키마 정의
+// Normalizr entity schema
 export const artistEntity = new schema.Entity('artists')
 export const songEntity = new schema.Entity('songs', {
   artists: [artistEntity],
@@ -269,8 +287,7 @@ export const fetchSong = createAsyncThunk(
   async (id: string) => {
     const data = await getSong(id)
     // 데이터를 정규화하여 리듀서가 예측 가능한 payload를 로드할 수 있도록 합니다:
-    // `action.payload = { songs: {}, artists: {} }`
-    const normalized = normalize(data, songEntity)
+    const normalized = normalize(data, songEntity)     // `action.payload = { songs: {}, artists: {} }`
     return normalized.entities
   }
 )
@@ -317,45 +334,53 @@ const reducer = slice.reducer
 export default reducer
 ```
 
-이 방법은 slice 분리의 이점을 다소 제한할 수 있지만, 우리가 제어할 수 없는 두 entity 간의 관계를 명확하게 나타냅니다. 만약 이러한 entity가 리팩토링되어야 한다면, 함께 리팩토링해야 할 것입니다.
+이 방법을 사용하면 slice 간 완전한 독립성은 조금 줄어들지만, 어차피 분리하기 힘든 두 entity 의 의존 관계를 코드에 명확하게 드러낼 수 있습니다.
+따라서 나중에 둘 중 하나를 수정할 때는, 연결된 엔티티까지 함께 리팩토링하는 것이 안전합니다.
 
-## 전역 타입과 Redux 
+## Global 타입과 Redux 
 
-전역 타입은 애플리케이션 전반에서 사용되는 타입을 의미하며, 크게 두 가지로 나눌 수 있습니다:<br/>
+Global 타입은 애플리케이션 전반에서 사용되는 타입을 의미하며, 크게 두 가지로 나눌 수 있습니다:<br/>
 1. 애플리케이션 특성이 없는 제너릭 타입
 2. 애플리케이션 전체에 알고 있어야 하는 타입 
 
-첫 번째 경우에는 관련 타입을 Shared 폴더 안에 적절한 segment로 배치하면 됩니다. 예를 들어, 분석 전역 변수를 위한 인터페이스가 있다면 `shared/analytics`에 두는 것이 좋습니다.
+
+### 1) 제너릭 타입
+
+첫 번째 경우에는 관련 타입을 Shared 폴더 안에 적절한 segment로 배치하면 됩니다. 예를 들어, 분석 전역 변수를 위한 Interface가 있다면 `shared/analytics`에 두는 것이 좋습니다.
 
 :::warning
 
-경고: `shared/types` 폴더를 생성하지 않는 것이 좋습니다. "타입"이라는 공통된 속성으로 관련 없는 항목들을 그룹화하면, 프로젝트에서 코드를 검색할 때 효율성이 떨어질 수 있습니다.
+`shared/types` 폴더는 만들지 않는 편이 좋습니다. “타입이기 때문”이라는 이유만으로 무관한 항목을 묶으면 코드 검색이 어려워집니다.
 
 :::
 
-두 번째 경우는 Redux를 사용하지만 RTK가 없는 프로젝트에서 자주 발생합니다. 최종 store 타입은 모든 reducer를 추가한 후에만 사용 가능하지만, 이 store 타입은 앱 전체에서 사용하는 selector에 필요합니다. 예를 들어, 일반적인 store 정의는 다음과 같습니다:
+### 2) 애플리케이션 Global 타입
+
+`Redux(순수 Redux + RTK 미사용)` 프로젝트에서 자주 나타납니다.
+모든 reducer를 합쳐야 store 타입이 완성되지만, 이 타입은 전역에서 selector에 필요합니다.
 
 ```ts title="app/store/index.ts"
-import { combineReducers, rootReducer } from "redux";
+import { combineReducers, createStore } from "redux";
 
 import { songReducer } from "entities/song";
 import { artistReducer } from "entities/artist";
 
 const rootReducer = combineReducers(songReducer, artistReducer);
-
 const store = createStore(rootReducer);
 
 type RootState = ReturnType<typeof rootReducer>;
 type AppDispatch = typeof store.dispatch;
 ```
 
-`shared/store`에서 `useAppDispatch`와 `useAppSelector`와 같은 타입이 지정된 Redux 훅을 사용하는 것이 좋지만, [layer에 대한 import 규칙][import-rule-on-layers] 때문에 App layer에서 `RootState`와 `AppDispatch`를 import 할 수 없습니다. 
+`shared/store`에서 `useAppDispatch`, `useAppSelector` 훅을 만들고 싶어도, [import 규칙][import-rule-on-layers] 때문에 App layer의 `RootState·AppDispatch`를 가져올 수 없습니다.
 
-> slice의 module은 더 낮은 layer에 위치한 다른 slice만 import 할 수 있습니다.
+> 한 slice의 module은 자신보다 하위 layer에 있는 slice만 import할 수 있습니다.
 
-이 경우 권장되는 해결책은 Shared와 App layer 간에 암묵적인 의존성을 만드는 것입니다. `RootState`와 `AppDispatch` 두 타입은 유지보수 필요성이 적고 Redux를 사용하는 개발자들에게 익숙하므로 큰 문제 없이 사용할 수 있습니다.
+#### 권장 해결책
 
-TypeScript에서는 다음과 같이 타입을 전역으로 선언할 수 있습니다: 
+
+Shared ↔ App layer 간에 암묵적 의존성을 허용합니다.
+두 타입은 변동 가능성이 작고 Redux 개발자에게 익숙하므로 부담이 적습니다.
 
 ```ts title="app/store/index.ts"
 /* 이전 코드 블록과 동일한 내용입니다… */
@@ -371,27 +396,32 @@ export const useAppDispatch = useDispatch.withTypes<AppDispatch>()
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 ```
 
-## 열거형 
+## 열거형(enum)
 
-**일반적으로 열거형(enum)은 사용되는 위치와 최대한 가까운 곳에 정의하는 것이 좋습니다**. 열거형이 특정 기능과 관련된 값을 나타낸다면, 해당 기능 내에 정의해야 합니다.
+- `가장 가까운 사용 위치`에 정의합니다.
+- `segment`는 사용 위치로 결정합니다.
+  - UI Toast 위치 → `ui` segment
+  - 백엔드 Response 상태 → `api` segment
 
-segment 선택도 사용 위치에 따라 달라져야 합니다. 예를 들어, 화면에서 토스트 위치를 나타내는 열거형이라면 ui segment에 두는 것이 좋고, 백엔드 응답 상태 등을 나타낸다면 api segment에 두는 것이 적합합니다.
+프로젝트 전역에서 공용으로 쓰이는 값(예: Response 상태, 디자인 토큰)은 `Shared`에 두고, 의미에 맞는 segment(`api`, `ui` 등)를 선택합니다.
 
-프로젝트 전반에서 공통으로 사용되는 열거형도 있습니다. 예를 들어, 일반적인 백엔드 응답 상태나 디자인 시스템 토큰 등이 있습니다. 이 경우 Shared에 두되, 열거형이 나타내는 것을 기준으로 segment를 선택하면 됩니다 (`api`는 응답 상태, `ui`는 디자인 토큰 등).
 
-## 타입 검증 스키마와 Zod
+## 타입 검증 Schema와 Zod
 
-데이터가 특정 형태나 제약 조건을 충족하는지 검증하려면 검증 스키마를 정의할 수 있습니다. TypeScript에서는 [Zod][ext-zod]와 같은 라이브러리를 많이 사용합니다. 검증 스키마는 가능하면 사용하는 코드와 같은 위치에 두는 것이 좋습니다.
+데이터 형태·제약을 검증하려면 [Zod][ext-zod] 같은 라이브러리로 검증 스키마를 정의합니다.
+가능하면 사용 코드와 같은 위치에 둡니다.
 
-검증 스키마는 데이터를 파싱하며, 파싱에 실패하면 오류를 발생시킵니다.([Data transfoer objects and mappers](#data-transfer-objects-and-mappers) 토론을 참조하세요.) 가장 일반적인 검증 사례 중 하나는 백엔드에서 오는 데이터에 대한 것입니다. 데이터가 스키마와 일치하지 않는 경우 요청을 실패시키기를 원하기 때문에, 보통 `api` segment에 스키마를 두는 것이 좋습니다.
+- 백엔드 Response 검증 → api segment 옆
+- 폼 입력 검증 → ui segment(또는 복잡할 경우 model)
 
-사용자 입력(예: 폼)으로 데이터를 받을 경우, 입력된 데이터에 대해 바로 검증이 이루어져야 합니다. 이 경우 스키마를 `ui` segment 내 폼 컴포넌트 옆에 두거나, `ui` segment가 너무 복잡하다면 `model` segment에 둘 수 있습니다.
+검증 schema는 DTO를 파싱하고, schema에 맞지 않으면 즉시 오류를 던집니다.  
+([Data transfer objects and mappers](#data-transfer-objects-and-mappers) 섹션도 참고하세요.)  
+특히 백엔드 Response이 schema와 일치하지 않을 때 Request을 실패시키면, 조기에 버그를 발견할 수 있으므로 schema를 `api` segment에 두는 편이 일반적입니다.
 
-## 컴포넌트 props와 context의 타입 정의 
+## Component props, context 타입
 
-보통 props나 context 인터페이스는 이를 사용하는 컴포넌트나 컨텍스트와 같은 파일에 두는 것이 가장 좋습니다. 만약 Vue나 Svelte처럼 단일 파일 컴포넌트를 사용하는 프레임워크에서 여러 컴포넌트 간에 해당 인터페이스를 공유해야 한다면, `ui` segment 내 동일 폴더에 별도의 파일을 만들어 정의할 수 있습니다.
-
-예를 들어, React의 JSX에서는 다음과 같이 정의합니다:
+일반적으로 `Component·Context 파일과 같은 파일`에 둡니다.
+단일 파일(Vue·Svelte 등)에서 여러 Component가 Interface를 공유해야 한다면, 같은 폴더(보통 `ui` segment)에 별도 파일을 만듭니다.
 
 ```ts title="pages/home/ui/RecentActions.tsx"
 interface RecentActionsProps {
@@ -403,7 +433,7 @@ export function RecentActions({ actions }: RecentActionsProps) {
 }
 ```
 
-Vue에서 인터페이스를 별도 파일에 저장한 예는 다음과 같습니다:
+Vue에서 Interface를 별도 파일에 저장한 예는 다음과 같습니다:
 
 ```ts title="pages/home/ui/RecentActionsProps.ts"
 export interface RecentActionsProps {
@@ -421,22 +451,31 @@ export interface RecentActionsProps {
 
 ## Ambient 선언 파일(*.d.ts) 
 
-[Vite][ext-vite]나 [ts-reset][ext-ts-reset] 같은 일부 패키지는 앱 전반에서 작동하기 위해 Ambient 선언 파일을 필요로 합니다. 이러한 파일들은 보통 크거나 복잡하지 않기 때문에 `src/` 폴더에 두어도 괜찮습니다. 더 정리된 구조를 위해 `app/ambient/` 폴더에 두는 것도 좋은 방법입니다.
+[Vite][ext-vite]나 [ts-reset][ext-ts-reset] 같은 일부 패키지는 전역 Ambient 선언이 필요합니다. 
 
-타이핑이 없는 패키지인 경우, 해당 패키지를 미타입으로 선언하거나 직접 타이핑을 작성할 수 있습니다. 이러한 타이핑을 위한 좋은 위치는 `shared/lib` 폴더 내의 `shared/lib/untyped-packages` 폴더입니다. 이 폴더에 `%LIBRARY_NAME%.d.ts` 파일을 생성하고 필요한 타입을 선언합니다
+- **단순**하면 `src/`에 두어도 무방  
+- 구조를 **명확히** 하려면 `app/ambient/`에 배치
+
+타입이 없는 패키지는 `shared/lib/untyped-packages/%LIB%.d.ts`에 직접 선언합니다.
+
+### 타입이 없는 외부 패키지
+
+타입 정의가 없는 패키지는 **미타입(declare module)으로 선언**하거나 **직접 타입**을 작성해야 합니다.  
+권장 위치는 `shared/lib/untyped-packages`. 이 폴더에 **`%LIBRARY_NAME%.d.ts`** 파일을 만들고 필요한 타입을 선언합니다.
 
 ```ts title="shared/lib/untyped-packages/use-react-screenshot.d.ts"
-// 이 라이브러리는 타입 정의가 없으며 작성하는 것을 생략했습니다.
+// 공식 타입 정의가 없는 라이브러리 예시
 declare module "use-react-screenshot";
 ```
 
 ## 타입 자동 생성 
 
-외부 소스로부터 타입을 생성하는 일은 흔히 발생합니다. 예를 들어, OpenAPI 스키마로부터 백엔드 타입을 생성하는 경우가 있습니다.<br/>
-이러한 타입을 위한 전용 위치를 코드베이스에 만드는 것이 좋습니다. 예를 들어 `shared/api/openapi`와 같은 위치가 적합합니다. 이상적으로는 이러한 파일이 무엇인지, 어떻게 재생성하는지 등을 설명하는 README 파일도 포함하는 것이 좋습니다.
+외부 schema(OpenAPI 등)로부터 타입을 생성하는 경우, 전용 디렉터리를 둡니다.<br/>
+예: `shared/api/openapi` — README에 `파일 용도·재생성 방법`을 기록하면 좋습니다.
 
 [import-rule-on-layers]: /docs/reference/layers#import-rule-on-layers
 [ext-type-fest]: https://github.com/sindresorhus/type-fest
 [ext-zod]: https://zod.dev
 [ext-vite]: https://vitejs.dev
 [ext-ts-reset]: https://www.totaltypescript.com/ts-reset
+


### PR DESCRIPTION
## Background

A complete rewrite of the Korean **Type Guide** documentation.

- Replaces ambiguous or literal‑translation terms with standard dev vocabulary.  
- Streamlines long sentences and re‑orders sections for faster lookup.  
- issue fix #819

### Structure
- Added **Business entity & mutual references** section.  
- Merged DTO/mapper and Zod validation notes under `api / ui` segments.  
- Consolidated Global types, Ambient declarations into one chapter.


### Why
- Mixed translated terms confused new contributors.  
- Layer rules were scattered, slowing onboarding.  
- Examples used outdated folder names not matching the current repo.


