### PR TITLE
docs(ko): translate API Requests guide to Korean

### DIFF
--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/examples/api-requests.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/examples/api-requests.mdx
@@ -1,0 +1,149 @@
+---
+sidebar_position: 4
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Handling API Requests
+
+## Shared API Requests
+
+Shared API request 로직은 `shared/api` 폴더에 두세요.  
+이렇게 하면 애플리케이션 전체에서 손쉽게 재사용할 수 있고, 빠른 프로토타이핑이 가능합니다.
+대부분의 프로젝트에서는 이 폴더 구조와 client.ts 설정만으로 충분합니다.
+
+일반적인 파일 구조 예시:
+- 📂 shared
+    - 📂 api
+        - 📄 client.ts
+        - 📄 index.ts
+        - 📂 endpoints
+            - 📄 login.ts
+
+`client.ts` 파일은 HTTP request 관련 설정을 **한 곳에서** 관리합니다.  
+`fetch()` 또는 `axios` instance에 공통 설정을 적용하여 다음을 처리합니다:
+
+- 백엔드 기본 URL  
+- Default headers (예: 인증 header) 
+- 데이터 직렬화  
+
+아래 예시를 참고하세요.
+
+<Tabs>
+
+<TabItem value="axios" label="Axios">
+```ts title="shared/api/client.ts"
+// Axios 예시
+import axios from 'axios';
+
+export const client = axios.create({
+  baseURL: 'https://your-api-domain.com/api/',
+  timeout: 5000,
+  headers: { 'X-Custom-Header': 'my-custom-value' }
+});
+```
+</TabItem>
+
+<TabItem value="fetch" label="Fetch">
+```ts title="shared/api/client.ts"
+export const client = {
+  async post(endpoint: string, body: any, options?: RequestInit) {
+    const response = await fetch(`https://your-api-domain.com/api${endpoint}`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom-Header': 'my-custom-value',
+        ...options?.headers,
+      },
+    });
+    return response.json();
+  }
+  // ... other methods like put, delete, etc.
+};
+```
+</TabItem>
+
+</Tabs>
+
+`shared/api/endpoints` 폴더에 endpoint별 request 함수를 정리하세요.
+
+:::note
+
+예시의 가독성을 위해 form handling과 검증(Zod·Valibot 등)은 생략했습니다.
+자세한 내용은 [Type Validation and Schemas](/docs/guides/examples/types#type-validation-schemas-and-zod)에서 확인하세요.
+
+:::
+
+```ts title="shared/api/endpoints/login.ts"
+import { client } from '../client';
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export function login(credentials: LoginCredentials) {
+  return client.post('/login', credentials);
+}
+```
+
+`shared/api/index.ts`에서 request 함수와 타입을 내보내세요:
+
+```ts title="shared/api/index.ts"
+export { client } from './client'; // If you want to export the client itself
+export { login } from './endpoints/login';
+export type { LoginCredentials } from './endpoints/login';
+```
+
+## Slice-specific API Requests
+
+특정 페이지나 feature에서만 쓰이는 request는 해당 slice의 api 폴더에 두어 정리하세요.
+이렇게 하면 slice별 로직이 깔끔하게 분리됩니다.
+
+- 📂 pages
+    - 📂 login
+        - 📄 index.ts
+        - 📂 api
+            - 📄 login.ts
+        - 📂 ui
+            - 📄 LoginPage.tsx
+
+```ts title="pages/login/api/login.ts"
+import { client } from 'shared/api';
+
+interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export function login(credentials: LoginCredentials) {
+  return client.post('/login', credentials);
+}
+```
+
+이 함수는 재사용 가능성이 낮으므로, slice의 public API로 내보낼 필요가 없습니다.
+
+:::note
+
+entities layer에 API request와 response 타입을 배치하지 마세요.
+백엔드 response 타입과 프론트엔드 `entities` 타입이 다를 수 있습니다.
+`shared/api`나 slice의 `api` 폴더에서 데이터를 변환하고, entities는 프론트엔드 관점에 집중하도록 설계하세요.
+
+:::
+
+## API 타입과 클라이언트 자동 생성
+
+백엔드에 OpenAPI 스펙이 있다면 [orval](https://orval.dev/)이나 [openapi-typescript](https://openapi-ts.dev/) 같은 도구로 API 타입과 request 함수를 생성할 수 있습니다.
+생성된 코드는 `shared/api/openapi` 등에 두고 `README.md`에 생성 방법과 타입 설명을 문서화하세요.
+
+## 서버 상태 라이브러리 연동
+
+[TanStack Query (React Query)](https://tanstack.com/query/latest)나 [Pinia Colada](https://pinia-colada.esm.dev/) 같은 서버 상태 관리 라이브러리를 사용할 때는 slice 간 타입이나 cache key를 공유해야 할 수 있습니다.
+이럴 때는 `shared` layer에 다음을 배치하세요.
+
+- API 데이터 타입 (API data types)
+- 캐시 키 (cache keys)
+- 공통 query/mutation 옵션 (common query/mutation options)

--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/examples/index.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/examples/index.mdx
@@ -5,32 +5,39 @@ hide_table_of_contents: true
 # Examples
 
 <p class="summary">
-방법론 적용에 대한 예시들
+FSD Architecture 적용 사례
 </p>
 
 ## Main
 
 import NavCard from "@site/src/shared/ui/nav-card/tmpl.mdx"
-import { UserSwitchOutlined, LayoutOutlined, FontSizeOutlined } from "@ant-design/icons";
+import { UserSwitchOutlined, LayoutOutlined, FontSizeOutlined, ApiOutlined } from "@ant-design/icons";
 
 <NavCard
-    title="권한"
-    description="인증 로직의 세분화"
+    title="Authentication"
+    description="인증 로직 구조화"
     to="/docs/guides/examples/auth"
     Icon={UserSwitchOutlined}
     tags={["Forms", "2FA", "OAuth", "Token storage", "Token refresh"]}
 />
 <NavCard
-    title="타입"
-    description="타입 위치 선정 및 FSD에서의 타입 종류"
+    title="Types"
+    description="FSD 환경에서 타입의 위치 및 유형"
     to="/docs/guides/examples/types"
     Icon={FontSizeOutlined}
     tags={["DTO", "Mappers", "Entity relationships", "Auto-generation", "Validation schemas"]}
 />
 <NavCard
-    title="페이지 레이아웃"
-    description="레이아웃의 활용 사례"
+    title="Page layouts"
+    description="layout 활용 사례"
     to="/docs/guides/examples/page-layout"
     Icon={LayoutOutlined}
     tags={["Where to store them", "Using widgets in layouts"]}
+/>
+<NavCard
+  title="API Requests"
+  description="공통 및 Slice-specific API Requests 관리"
+  to="/docs/guides/examples/api-requests"
+  Icon={ApiOutlined}
+  tags={["Shared API", "Slice-specific API", "Client Generators", "Server State"]}
 />

--- a/i18n/kr/docusaurus-plugin-content-docs/current/guides/examples/types.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/guides/examples/types.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 ---
 
-# 타입
+# Types
 
 이 가이드는 TypeScript 같은 정적 타입 언어에서 데이터를 정의·활용하는 방법과, FSD 구조 내에서 타입을 어디에 배치할지 설명합니다.
 


### PR DESCRIPTION
## Background

### api-requests guide translation
- Translated the `Shared API Requests` section into Korean.
- Translated the `Slice-specific API Requests` section into Korean.
- Translated the `API Types & Client Generators` section into Korean.
- Translated the `Integrating with Server State Libraries` section into Korean.

### Examples page improvements 

- Changed page summary from "방법론 적용에 대한 예시들" to "FSD Architecture 적용 사례" because the term “methodology” was confusing.
- Unified NavCard titles to English ("Authentication", "Types", "Page layouts") for better readability.
- Imported ApiOutlined icon and added a new NavCard for "API Requests" with description "공통 및 Slice-specific API Requests 관리".