### PR TITLE
docs(ko): refine reference for improved readability

### DIFF
--- a/i18n/kr/docusaurus-plugin-content-docs/current/reference/index.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/reference/index.mdx
@@ -1,0 +1,33 @@
+---
+sidebar_position: 0
+hide_table_of_contents: true
+pagination_prev: guides/index
+---
+
+import NavCard from "@site/src/shared/ui/nav-card/tmpl.mdx"
+import { ApiOutlined, GroupOutlined, AppstoreOutlined, NodeIndexOutlined } from "@ant-design/icons";
+
+# 📚 Reference
+
+<p class="summary">
+Feature-Sliced Design의 핵심 개념을 자세히 설명합니다.
+</p>
+
+<NavCard
+    title="Layers" 
+    description="Layer의 정의와 각 Layer별 역할, 구성 방식"
+    to="/docs/reference/layers"
+    Icon={GroupOutlined}
+/>
+<NavCard
+    title="Slices and segments" 
+    description="Slice와 Segment의 정의, Segment 유형과 Layer별 구성 예시"
+    to="/docs/reference/slices-segments"
+    Icon={AppstoreOutlined}
+/>
+<NavCard
+    title="Public API" 
+    description="Public API의 정의와 목표, @x 표기를 사용한 Cross-import 방법, 문제 해결 가이드"
+    to="/docs/reference/public-api"
+    Icon={ApiOutlined}
+/>

--- a/i18n/kr/docusaurus-plugin-content-docs/current/reference/layers.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/reference/layers.mdx
@@ -3,104 +3,103 @@ sidebar_position: 1
 pagination_next: reference/slices-segments
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 # Layer
 
-Layer는 Feature-Sliced Design의 계층 구조에서 가장 상위 수준을 담당하며, Layer > Slice > Segment로 구성된 구조의 첫 번째 단계입니다. 
-Layer의 목적은 코드가 얼마나 많은 책임을 가져야 하는지와 앱 내 다른 모듈들에 얼마나 의존하는지에 따라 코드를 분리하는 것입니다.
-또한, 각 Layer는 코드에 할당해야 하는 책임의 정도를 결정하는 데 도움이 되는 특별한 의미를 가지고 있습니다.
+Layer는 Feature-Sliced Design에서 **코드를 구분하는 가장 큰 범위**입니다.  
+코드를 나눌 때는 각 부분이 **어떤 기능을 담당하는지**와 **다른 코드에 얼마나 의존하는지**를 기준으로 합니다.  
+Layer마다 **어떤 역할을 맡는지**에 대한 공통된 의미가 있습니다.
 
-총 **7개의 Layer**가 있으며, 가장 많은 책임과 의존성을 가진 것부터 가장 적은 것까지 순서대로 배열되어 있습니다:
+총 **7개의 Layer**가 있으며, **담당 기능과 의존성이 많은 것**부터 **적은 것** 순으로 나열합니다.
 
-<img src="/img/layers/folders-graphic-light.svg#light-mode-only" width="180" style={{ float: "right", margin: "0 1em" }} alt="A file system tree, with a single root folder called src and then seven subfolders: app, processes, pages, widgets, features, entities, shared. The processes folder is slightly faded out." />
-<img src="/img/layers/folders-graphic-dark.svg#dark-mode-only" width="180" style={{ float: "right", margin: "0 1em" }} alt="A file system tree, with a single root folder called src and then seven subfolders: app, processes, pages, widgets, features, entities, shared. The processes folder is slightly faded out." />
+<img src={useBaseUrl("/img/layers/folders-graphic-light.svg#light-mode-only")} width="180" style={{ float: "right", margin: "0 1em" }} alt="A file system tree, with a single root folder called src and then seven subfolders: app, processes, pages, widgets, features, entities, shared. The processes folder is slightly faded out." />
+<img src={useBaseUrl("/img/layers/folders-graphic-dark.svg#dark-mode-only")} width="180" style={{ float: "right", margin: "0 1em" }} alt="A file system tree, with a single root folder called src and then seven subfolders: app, processes, pages, widgets, features, entities, shared. The processes folder is slightly faded out." />
 
-1. App
-2. Processes (deprecated)
-3. Pages
-4. Widgets
-5. Features
-6. Entities
+1. App  
+2. Processes (deprecated)  
+3. Pages  
+4. Widgets  
+5. Features  
+6. Entities  
 7. Shared
 
-모든 Layer를 사용할 필요는 없습니다. 프로젝트에 필요한 Layer만 선택적으로 사용하면 됩니다. 일반적으로 대부분의 Frontend 프로젝트는 최소한 Shared, Pages, App Layer를 포함합니다.
+> 모든 Layer를 꼭 써야 하는 건 아닙니다. **필요할 때만** 추가하세요.  
+> 대부분의 프론트엔드 프로젝트는 최소한 `shared`, `page`, `app`은 포함합니다.
 
-각 Layer는 소문자 폴더명으로 구성됩니다(예: `📁 shared`, `📁 pages`, `📁 app`). Layer의 역할은 표준화되어 있어 _새로운 Layer 추가는 권장되지 않습니다_.
+실무에서는 폴더명을 소문자로 작성합니다(예: `📁 shared`, `📁 page`, `📁 app`).  
+**새로운 Layer를 만드는 것은 권장하지 않습니다**(역할이 이미 표준화되어 있음).
 
 ## Import 규칙
 
-Layer는 높은 응집도를 가진 모듈 그룹인 Slice로 구성됩니다. Slice 간 의존성은 **Layer의 Import 규칙**을 따릅니다:
+Layer는 **Slice(서로 밀접하게 연관된 모듈 묶음)** 로 구성됩니다.  
+Slice 간 연결은 **Layer Import 규칙**으로 제한합니다.
 
-> _Slice 내부 모듈은 자신보다 하위 Layer의 Slice만 Import할 수 있습니다._
+> **규칙**: Slice 안의 코드는 **자신보다 아래 Layer**의 *다른 Slice*만 Import할 수 있습니다.
 
-예시) `📁 ~/features/aaa` 폴더("aaa" Slice)의 `~/features/aaa/api/request.ts` 파일:
-  - 같은 Layer의 `📁 ~/features/bbb` Import 불가
-  - 하위 Layer인 `📁 ~/entities`와 `📁 ~/shared`는 Import 가능
-  - 같은 Slice 내 파일(`~/features/aaa/lib/cache.ts`) Import 가능
+예: `📁 ~/features/aaa/api/request.ts`는  
+- 같은 Layer의 `📁 ~/features/bbb` → **불가능**  
+- 더 아래 Layer(`📁 ~/entities`, `📁 ~/shared`) → **가능**  
+- 같은 Slice(`📁 ~/features/aaa/lib/cache.ts`) → **가능**
 
-App과 Shared Layer는 **예외**입니다.<br/>
-이들은 Layer이면서 동시에 Slice 역할을 합니다.
+`app`과 `shared`는 **예외**입니다.  
+두 Layer는 **Layer이면서 동시에 하나의 큰 Slice처럼 동작**하고, 내부는 **Segment**로 나눕니다.  
+이 경우 Segment끼리 자유롭게 Import할 수 있습니다.  
+(`shared`는 비즈니스 도메인이 없고, `app`은 모든 도메인을 묶는 역할을 합니다.)
 
-일반 Slice는 비즈니스 도메인별로 코드를 분리하지만, Shared는 공통 코드를, App은 전체 도메인 통합을 담당합니다.
+## Layer별 역할
 
-따라서 App과 Shared Layer는 Segment로 구성되며, Segment 간 자유로운 Import가 가능합니다.
-
-## Layer 정의
+각 Layer가 어떤 의미를 가지며, 어떤 코드를 포함하는지 정리했습니다.
 
 ### Shared
 
-Shared Layer는 애플리케이션의 기반을 형성합니다.<br/>
-Backend, 외부 라이브러리, 환경 설정 등을 관리하며, 자체 라이브러리도 정의합니다.
+앱의 **기본 구성 요소**를 모아둡니다.  
+백엔드, 서드파티 라이브러리, 실행 환경과의 연결, 그리고 **높은 응집도의 내부 라이브러리**를 포함합니다.
 
-App Layer처럼 Shared Layer도 _Slice를 포함하지 않습니다_.<br/>
-Slice는 비즈니스 도메인 분리용이지만, Shared는 도메인 독립적이기 때문입니다.<br/>
-따라서 Shared Layer 내 파일들은 자유롭게 서로 Import할 수 있습니다.
+- `app`과 마찬가지로 **Slice 없이 Segment로만 구성**합니다.  
+- 비즈니스 도메인이 없으므로 **Shared 안의 파일끼리는 자유롭게 Import**할 수 있습니다.
 
-주요 Segment:
+Segment 예시
+- `📁 api` — API 클라이언트와 백엔드 요청 함수
+- `📁 ui` — 공통 UI 컴포넌트  
+  - **비즈니스 로직 제외**, **브랜드 테마 적용 가능**  
+  - 로고, 레이아웃, 자동완성/검색창 등 UI 로직 포함 가능
+  - 자동완성/검색창 등 **UI 로직 컴포넌트**도 가능
+- `📁 lib` — 내부 라이브러리  
+  - 단순 `utils/helpers` 모음이 아님 ([이 글 참고][ext-sova-utility-dump])  
+  - 하나의 주제(날짜, 색상, 텍스트 등)에 집중  
+  - README로 역할과 범위를 문서화
+- `📁 config` — 환경변수, 전역 Feature Flag
+- `📁 routes` — 라우트 상수/패턴
+- `📁 i18n` — 번역 설정, 전역 문자열
 
-- `📁 api` — API client와 Backend endpoint 요청 함수
-- `📁 ui` — Application UI kit
-  - 비즈니스 로직 제외, 비즈니스 테마 허용
-  - 회사 로고, 페이지 layout 등 포함 가능
-  - UI 로직 Component(자동완성, 검색창 등) 포함 가능
-- `📁 lib` — 내부 라이브러리
-  - 단순 utility 폴더가 아님([참고][ext-sova-utility-dump])
-  - 각 라이브러리는 특정 영역(날짜, 색상, 텍스트 처리 등) 담당
-  - README로 명확한 문서화 필요
-- `📁 config` — 전역 설정(환경 변수, feature flag 등)
-- `📁 routes` — Route 상수와 패턴
-- `📁 i18n` — i18n 설정과 전역 번역
+> Segment 이름은 **무엇을 하는 폴더인지** 드러나야 합니다.  
+> `components`, `hooks`, `types`처럼 역할이 불명확한 이름은 피하세요.
 
-추가 Segment는 가능하나 목적이 명확해야 합니다. `components`, `hooks`, `types`같은 모호한 이름은 지양합니다.
+### Entities
 
-### Entity
+프로젝트에서 다루는 **핵심 데이터 개념**을 나타냅니다.  
+비즈니스 용어(예: `User`, `Post`, `Product`)와 일치하는 경우가 많습니다.
 
-**Entity Slice**는 다음 요소들을 포함할 수 있습니다:
+Entity Slice에는 다음을 포함할 수 있습니다:
 
-- Data Store (`📁 model`)
-Entity 관련 데이터 구조와 상태 관리
+구성
+- `📁 model` — 데이터 상태와 검증 스키마
+- `📁 api` — 해당 Entity의 API 요청
+- `📁 ui` — Entity의 시각적 표현  
+  - 완전한 UI 블록이 아니어도 됨  
+  - 여러 페이지에서 재사용 가능하게 설계  
+  - 비즈니스 로직은 props/slot으로 연결 권장
 
-- Data Validation Schema (`📁 model`)
-Entity 데이터 검증을 위한 schema 정의
 
-- API Request Function (`📁 api`)
-Entity 관련 API request function
+#### Entity 간 관계
 
-- Entity UI 표현 (`📁 ui`)
-Interface에서 Entity의 시각적 표현
-  - 완전한 UI block 생성은 불필요
-  - 여러 page에서 재사용 가능한 디자인
-  - Business logic은 props나 slot으로 연결
+원칙적으로 Slice끼리는 서로 모르면 좋습니다.  
+하지만 현실적으로 **다른 Entity를 포함**하거나 **상호작용**하는 경우가 있습니다.  
+이때는 로직을 **상위 Layer(Feature/Page)** 로 올려 처리하세요.
 
-#### Entity 관계
-
-FSD에서 Entity는 Slice이며, 기본적으로 각 Slice는 독립적입니다. 하지만 실제로는 Entity 간 상호작용이 필요합니다. 때로는 한 Entity가 다른 Entity를 포함하기도 합니다.<br/>
-이러한 Entity 간 Business logic은 Features나 Pages 같은 상위 Layer에서 관리하는 것이 좋습니다.
-
-한 Entity의 data object가 다른 data object를 포함할 때는 `@x` 표기법으로 Entity 간 연결을 명시합니다.
-  - 이는 Slice 격리를 우회하면서 Entity 관계를 명확히 표현
-  - 연결된 Entity들은 함께 refactoring될 가능성이 높음
-
-예를 들어:
+만약 한 Entity 데이터에 다른 Entity가 포함된다면,  
+`@x` 표기를 사용해 **교차 Public API**로 연결을 명시적으로 드러내세요.
 
 ```ts title="entities/artist/model/artist.ts"
 import type { Song } from "entities/song/@x/artist";
@@ -111,94 +110,74 @@ export interface Artist {
 }
 ```
 
-```ts title="entities/song/@x/artist.ts"
-export type { Song } from "../model/song.ts";
-```
-
-`@x` 표기법에 대한 자세한 내용은 [Cross-Import를 위한 Public API][public-api-for-cross-imports]를 참조하세요.
+자세한 내용은 [Cross-Import를 위한 Public API][public-api-for-cross-imports]를 참고하세요.
 
 ### Feature
 
-이 Layer는 사용자의 주요 상호작용을 처리합니다.<br/>
-이러한 상호작용은 앱의 Business Entity와 밀접하게 연관됩니다.
+사용자가 앱에서 수행하는 주요 기능을 담습니다.
+보통 특정 Entity와 연결됩니다.
 
-Feature Layer 사용 시 중요한 원칙은 **모든 것을 Feature로 만들 필요는 없다**는 점입니다.<br/>
-Feature 정의의 좋은 기준은 여러 page에서의 재사용 여부입니다.
+- 모든 기능을 Feature로 만들 필요는 없습니다. 여러 페이지에서 재사용되는 경우에만 고려하세요.
+- 예: 여러 에디터에서 같은 댓글 기능을 쓴다면, comments를 Feature로 만듭니다.
+- Feature가 너무 많으면 중요한 기능을 찾기 어려워집니다.
 
-예시) 여러 editor에서 공통으로 사용되는 comment 기능은 재사용 가능한 Feature가 될 수 있습니다.<br/>
-단, Feature Layer는 코드 탐색 메커니즘이므로, 너무 많은 Feature는 중요 기능을 찾기 어렵게 만듭니다.
+구성
+- 📁 ui — 상호작용 UI(예: 폼)
+- 📁 api — 기능 관련 API 요청
+- 📁 model — 검증, 내부 상태
+- 📁 config — Feature Flag
 
-이상적으로는, 새로운 프로젝트 참여 시 Page와 Feature 검토만으로 프로젝트의 기능을 파악할 수 있어야 합니다.
-
-Feature Slice는 다음을 포함할 수 있습니다:
-- 상호작용 UI (`📁 ui`)
-- API 호출 (`📁 api`)
-- 검증 및 상태 관리 (`📁 model`)
-- Feature Flag (`📁 config`)
+> 새로운 팀원이 들어왔을 때 Page와 Feature만 봐도 앱 기능 구조를 파악할 수 있도록 구성하세요.
 
 ### Widget
 
-Widget Layer는 독립적인 대형 UI Block을 구성하는 Layer입니다.<br/>
-Widget은 여러 page에서 재사용되거나, 한 page 내 여러 독립 Block이 필요할 때 적합합니다.
-
-단, UI Block이 page의 주요 내용이고 재사용되지 않는다면,
-**Widget으로 분리하지 말고** page 내부에 직접 구현하는 것이 좋습니다.
+독립적으로 동작하는 큰 UI 블록입니다.  
+여러 페이지에서 재사용되거나, 한 페이지에 큰 블록이 여럿 있을 때 유용합니다. 
 
 :::tip
 
-[Remix][ext-remix]와 같은 Nested Routing System 사용 시 Widget Layer가 유용합니다.
-Widget Layer는 Page Layer와 유사하게 작동하여:
-- Data Fetching
-- Loading State
-- Error Boundary
-등을 포함한 완전한 Router Block 생성이 가능합니다.
-
-또한 Page Layout도 이 Layer에서 관리할 수 있습니다.
+- 재사용되지 않고 특정 페이지의 핵심 콘텐츠라면 Widget으로 분리하지 말고 Page 안에 두세요.
+- Nested Routing(예: [Remix][ext-remix]) 환경에서는 Widget이 **Page와 유사한 방식**으로 동작합니다.  
+  예를 들어, 데이터 로딩, 로딩 상태 표시, 에러 처리 등을 포함해 **하나의 라우터 단위 블록**을 구성할 수 있습니다.
 
 :::
 
 ### Page
 
-Page Layer는 웹사이트와 Application의 screen 또는 activity를 나타냅니다.<br/>
-보통 하나의 page는 하나의 Slice이지만, login/register form처럼 유사한 page들은 하나의 Slice로 그룹화할 수 있습니다.
+웹/앱의 **화면(screen) 또는 액티비티(activity)** 에 해당합니다.
+대부분 페이지 1개 = Slice 1개이지만, 유사한 페이지는 하나의 Slice로 묶을 수 있습니다.
 
-팀이 코드를 쉽게 찾을 수 있다면, Page Slice 내 코드 양에 제한은 없습니다.<br/>
-특히 재사용되지 않는 UI Block은 Page Slice 내부에 두는 것이 좋습니다.
+- 코드 찾기만 쉽다면 Page Slice 크기 제한은 없습니다.
+- 재사용되지 않는 UI는 Page 안에 둡니다.
+- 보통 전용 모델은 없고, 간단한 상태만 컴포넌트 내부에서 관리합니다.
 
-Page Slice 구성요소:
-
-- UI Block과 State 관리 (`📁 ui`)
-  - Page UI, Loading State, Error Boundary 관리
-- Data 처리 (`📁 api`)
-  - Data Fetching과 Mutation 처리
-
-일반적으로 Page는 전용 Data Model을 갖지 않으며,<br/>
-작은 State는 Component 내부에서 관리합니다.
+구성 예
+- 📁 ui — UI, 로딩 상태, 에러 처리
+- 📁 api — 데이터 패칭/변경 요청
 
 ### Process
 
 :::caution
 
-이 Layer는 Deprecated되었습니다. 관련 로직을 `features`와 `app` Layer로 이동하는 것을 권장합니다.
+Deprecated — 기존 코드는 feature나 app으로 옮기세요.
 
 :::
 
-Process Layer는 multi-page 상호작용을 위한 대안이었으나, 의도적으로 모호하게 정의되었으며 사용을 권장하지 않습니다.
-
-Router Level과 Server Level 로직은 App Layer에 포함하는 것이 좋습니다. App Layer가 너무 커지거나 로직 분리가 필요할 때만 Process Layer 사용을 고려하세요.
+과거에는 여러 페이지를 넘나드는 기능을 위한 탈출구 역할이었지만,
+정의가 모호해 대부분의 앱에서는 사용하지 않습니다.  
+라우터, 서버 레벨 로직은 App Layer에 두고, App이 너무 커질 때만 제한적으로 고려하세요.
 
 ### App
 
-App Layer는 Application 전반의 기술적(Context Provider)이고 비즈니스적(Analytics)인 문제를 다룹니다.
+앱 전역에서 동작하는 **환경 설정**과 **공용 로직**을 관리하는 Layer입니다.    
+예를 들어, 라우터 설정, 전역 상태 관리, 글로벌 스타일, 진입점 설정 등 **앱 전체에 영향을 주는 코드**를 둡니다.
 
-Shared Layer처럼 Slice를 포함하지 않고, 직접 Segment로 구성됩니다.
-
-주요 Segment:
-
-- `📁 routes` — Router 설정
-- `📁 store` — Global State Store 설정
-- `📁 styles` — Global Style
-- `📁 entrypoint` — Application Entry Point와 Framework 설정
+- shared처럼 Slice 없이 Segment로 구성합니다.
+- 대표 Segment:
+  - `📁 routes` — Router 설정
+  - `📁 store` — Global State Store 설정
+  - `📁 styles` — Global Style
+  - `📁 entrypoint` — Application Entry Point와 Framework 설정
 
 [public-api-for-cross-imports]: /docs/reference/public-api#public-api-for-cross-imports
 [ext-remix]: https://remix.run

--- a/i18n/kr/docusaurus-plugin-content-docs/current/reference/public-api.md
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/reference/public-api.md
@@ -134,7 +134,7 @@ export { loadUserStatistics } from "./api/loadUserStatistics";
 여기서 `Button` 하나만 사용해도 `carousel`이나 `accordion` 같은 무거운 의존성이 번들에 포함될 수 있습니다.  
 특히 Syntax Highlighter, Drag-and-Drop 라이브러리처럼 용량이 큰 의존성은 영향을 크게 줍니다.
 
-### 해결 방법
+#### 해결 방법
 
 - 각 컴포넌트/라이브러리별로 별도 Index 파일 생성
 

--- a/i18n/kr/docusaurus-plugin-content-docs/current/reference/slices-segments.mdx
+++ b/i18n/kr/docusaurus-plugin-content-docs/current/reference/slices-segments.mdx
@@ -6,21 +6,24 @@ pagination_next: reference/public-api
 
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-# Slice와 Segment
+# Slices and segments
 
 ## Slice
 
-Slice는 Feature-Sliced Design의 두 번째 구성 단위입니다. Slice의 주 목적은 제품, 비즈니스, Application 관점에서 코드를 체계적으로 그룹화하는 것입니다.
+Slice는 Feature-Sliced Design 조직 구조의 **두 번째 계층**입니다.  
+주 목적은 제품, 비즈니스, 또는 단순히 애플리케이션 관점에서 **관련 있는 코드를 하나로 묶는 것**입니다.
 
-Slice 이름은 표준화되어 있지 않고 Application의 비즈니스 도메인에 따라 결정됩니다. 예시:
+Slice의 이름은 표준화되어 있지 않고, 애플리케이션의 비즈니스 도메인에 따라 결정됩니다. 예를 들어:
 - 사진 갤러리: `photo`, `effects`, `gallery-page`
 - 소셜 네트워크: `post`, `comments`, `news-feed`
 
-Shared와 App Layer는 Slice를 포함하지 않습니다. Shared는 Business Logic을 포함하지 않고, App은 Application 전체 관련 코드만 다루기 때문입니다.
+`Shared`와 `App` Layer는 Slice를 포함하지 않습니다.  
+Shared는 비즈니스 로직이 전혀 없어 제품 관점에서 의미가 없고, App은 애플리케이션 전체를 다루기 때문에 별도로 나눌 필요가 없습니다.
 
-### Zero 결합도과 High 응집도 {#zero-coupling-high-cohesion}
+### Zero 결합도와 높은 응집도 {#zero-coupling-high-cohesion}
 
-Slice는 독립적이고 응집도 높은 코드 그룹이어야 합니다. 아래 그래픽은 _응집도_과 _결합도_ 개념을 시각화합니다:
+Slice는 **다른 Slice와 독립적**이며, **자신의 핵심 목적과 관련된 대부분의 코드**를 포함해야 합니다.  
+아래 그림은 **응집도(cohesion)** 와 **결합도(coupling)** 개념을 시각적으로 설명합니다.
 
 <figure>
     <img src={useBaseUrl("/img/coupling-cohesion-light.svg#light-mode-only")} alt="" />
@@ -30,33 +33,32 @@ Slice는 독립적이고 응집도 높은 코드 그룹이어야 합니다. 아�
     </figcaption>
 </figure>
 
-이상적인 Slice 특징:
-    1. 독립적 — 같은 Layer의 다른 Slice와 Zero 결합도
-    2. 높은 응집도 — 핵심 목적 관련 코드를 포함
+Slice의 독립성은 [Layer Import Rule][layers--import-rule]로 보장됩니다.
 
-Slice의 독립성은 [Layer Import Rule][layers--import-rule]로 강제됩니다:
+> _Slice 내부의 모듈(파일)은 자신보다 아래 계층(Layer)에 있는 Slice만 import할 수 있습니다._
 
-> _Slice의 모듈은 하위 Layer의 다른 Slice만 Import 가능_
+### Slice의 Public API 규칙
 
-### Slice의 Public API Rule
+Slice 내부 구조는 **팀이 원하는 방식대로 자유롭게** 구성할 수 있습니다.  
+단, 다른 Slice가 사용할 수 있도록 **명확한 Public API**를 반드시 제공해야 합니다.  
+이 규칙은 **Slice Public API Rule**로 강제됩니다.
 
-Slice 내부 구조는 자유롭지만, 다른 Slice가 사용할 좋은 Public API를 제공해야 합니다. 이는 **Slice Public API Rule**로 강제됩니다:
+> _모든 Slice(또는 Slice가 없는 Layer의 Segment)는 Public API를 정의해야 합니다._  
+> _외부 모듈은 Slice/Segment의 내부 구조가 아니라 Public API를 통해서만 접근할 수 있습니다._
 
-> _모든 Slice(와 Slice가 없는 Layer의 Segment)는 Public API를 정의해야 합니다._
->
-> _외부 모듈은 Slice/Segment의 내부 구조가 아닌 Public API만 참조 가능_
-
-자세한 내용은 [Public API Reference][ref-public-api]를 참고하세요.
+Public API의 목적과 작성 방법은 [Public API Reference][ref-public-api]에서 자세히 설명합니다.
 
 ### Slice Group
 
-연관된 Slice들은 폴더로 그룹화할 수 있습니다. 단, 다른 Slice와 동일한 격리 규칙을 따라야 하며, 그룹 내 **코드 공유는 불가능**합니다.
+연관성이 높은 Slice는 폴더로 묶어서 관리할 수 있습니다.  
+단, 다른 Slice와 동일하게 **격리 규칙**을 적용해야 하며, 그룹 내부에서도 **코드 공유는 불가능**합니다.
 
 ![Features "compose", "like" 그리고 "delete"가 "post" 폴더에 그룹화되어 있습니다. 해당 폴더에는 허용되지 않음을 나타내기 위해 취소선이 그어진 "some-shared-code.ts" 파일도 있습니다.](/img/graphic-nested-slices.svg)
 
 ## Segment
 
-Segment는 마지막 구성 단위로, 기술적 특성에 따라 코드를 그룹화합니다.
+Segment는 FSD 구조에서 **세 번째이자 마지막 계층**이며,  
+코드를 **기술적 성격**에 따라 그룹화합니다.
 
 표준 Segment:
 
@@ -66,11 +68,13 @@ Segment는 마지막 구성 단위로, 기술적 특성에 따라 코드를 그�
 - `lib` — Slice 내부 Library 코드
 - `config` — Configuration과 Feature Flag
 
-각 Layer의 Segment 사용법은 [Layer Page][layers--layer-definitions]를 참조하세요.
+각 Layer에서 Segment를 어떻게 활용하는지는 [Layer 페이지][layers--layer-definitions]를 참고하세요.
 
-Custom Segment도 생성 가능하며, App과 Shared Layer에서 주로 사용됩니다.
+또한 **커스텀 Segment**를 만들 수 있습니다.  
+특히 `App` Layer와 `Shared` Layer는 Slice가 없기 때문에, 커스텀 Segment가 자주 사용됩니다.
 
-Segment 이름은 코드 목적을 명확히 해야 합니다. `components`, `hooks`, `types`같은 모호한 이름은 피하세요.
+Segment 이름은 **내용의 본질(components/hooks/types)** 이 아니라 **목적**을 설명해야 합니다.  
+예를 들어 `components`, `hooks`, `types` 같은 이름은 찾을 때 도움이 되지 않으므로 피하세요.
 
 [layers--layer-definitions]: /docs/reference/layers#layer-definitions
 [layers--import-rule]: /docs/reference/layers#import-rule-on-layers


### PR DESCRIPTION
## Background

In this PR, I thoroughly revised the Korean translation of the official FSD documentation, focusing on the Layers, Slices & Segments, Public API, and Reference pages.
Rather than providing a direct translation, I refined the content to improve readability and clarity, ensuring that frontend developers can quickly and intuitively understand the concepts.