### PR TITLE
docs(sidebar): unify docs sidebar across sections

### DIFF
--- a/config/docusaurus/sidebars.docs.js
+++ b/config/docusaurus/sidebars.docs.js
@@ -32,8 +32,10 @@ const getSidebar = (category) => [
 ];
 
 module.exports = {
-    getstartedSidebar: getSidebar("get-started"),
-    guidesSidebar: getSidebar("guides"),
-    referenceSidebar: getSidebar("reference"),
-    aboutSidebar: getSidebar("about"),
+    docsSidebar: [
+        ...getSidebar("get-started"),
+        ...getSidebar("guides"),
+        ...getSidebar("reference"),
+        ...getSidebar("about"),
+    ],
 };


### PR DESCRIPTION
## Background

Previously, the docs had separate sidebars per section (Get started, Guides, Reference, About). While reading a page, you couldn’t see or jump to content from other sections without first navigating back to the docs landing and selecting the new section (2 clicks). This fragmented the global structure and made cross‑section navigation harder.

This PR unifies the docs navigation into a single sidebar that is always visible on every docs page. It improves discoverability and reduces navigation to a single click, without changing any URLs or document slugs.

## Changelog

1. Replace multiple per‑section sidebars with a single global docsSidebar composed of autogenerated categories.
2. Make the full documentation structure always visible in the left sidebar.
3. Enable one‑click switching between sections from any docs page (previously required going to the landing page and then choosing a section = 2 clicks).
4. No route/URL changes; only sidebar configuration updated. Local build passes.