### PR TITLE
feat(i18n): add Vietnamese translation

### DIFF
--- a/config/docusaurus/i18n.js
+++ b/config/docusaurus/i18n.js
@@ -3,7 +3,7 @@ const { DEFAULT_LOCALE } = require("./consts");
 /** @type {import('@docusaurus/types').DocusaurusConfig["i18n"]} */
 const i18n = {
     defaultLocale: DEFAULT_LOCALE,
-    locales: ["ru", "en", "uz", "kr", "ja"],
+    locales: ["ru", "en", "uz", "kr", "ja", "vi"],
     localeConfigs: {
         ru: {
             label: "Русский",
@@ -19,6 +19,9 @@ const i18n = {
         },
         ja: {
             label: "日本語",
+        },
+        vi: {
+            label: "Tiếng Việt",
         },
     },
 };

--- a/i18n/vi/code.json
+++ b/i18n/vi/code.json
@@ -1,0 +1,386 @@
+{
+    "pages.home.features.title": {
+        "message": "Tính năng",
+        "description": "Features"
+    },
+    "pages.home.features.logic.title": {
+        "message": "Business logic rõ ràng",
+        "description": "Feature title"
+    },
+    "pages.home.features.logic.description": {
+        "message": "Kiến trúc dễ khám phá nhờ phân chia theo domain scopes",
+        "description": "Feature description"
+    },
+    "pages.home.features.adaptability.title": {
+        "message": "Khả năng thích ứng",
+        "description": "Feature title"
+    },
+    "pages.home.features.adaptability.description": {
+        "message": "Các components trong kiến trúc có thể linh hoạt thay thế và thêm mới cho các requirements mới",
+        "description": "Feature description"
+    },
+    "pages.home.features.debt.title": {
+        "message": "Tech debt & Refactoring",
+        "description": "Feature title"
+    },
+    "pages.home.features.debt.description": {
+        "message": "Mỗi module có thể được chỉnh sửa / viết lại độc lập mà không có side effects",
+        "description": "Feature description"
+    },
+    "pages.home.features.shared.title": {
+        "message": "Code reuse rõ ràng",
+        "description": "Feature title"
+    },
+    "pages.home.features.shared.description": {
+        "message": "Duy trì sự cân bằng giữa DRY và customization cục bộ",
+        "description": "Feature description"
+    },
+    "pages.home.concepts.title": {
+        "message": "Khái niệm",
+        "description": "Concepts"
+    },
+    "pages.home.concepts.public.title": {
+        "message": "Public API",
+        "description": "Concept title"
+    },
+    "pages.home.concepts.public.description": {
+        "message": "Mỗi module phải khai báo public API của nó ở top level",
+        "description": "Concept description"
+    },
+    "pages.home.concepts.isolation.title": {
+        "message": "Isolation",
+        "description": "Concept title"
+    },
+    "pages.home.concepts.isolation.description": {
+        "message": "Module không nên phụ thuộc trực tiếp vào các module khác cùng layer hoặc layer phía trên",
+        "description": "Concept description"
+    },
+    "pages.home.concepts.needs.title": {
+        "message": "Needs Driven (Hướng theo nhu cầu)",
+        "description": "Concept title"
+    },
+    "pages.home.concepts.needs.description": {
+        "message": "Định hướng theo nhu cầu business và người dùng",
+        "description": "Concept description"
+    },
+    "pages.home.scheme.title": {
+        "message": "Sơ đồ kiến trúc",
+        "description": "Scheme"
+    },
+    "pages.home.companies.using": {
+        "message": "Công ty đang dùng FSD",
+        "description": "Companies using FSD"
+    },
+    "pages.home.companies.add_me": {
+        "message": "Công ty bạn đang dùng FSD?",
+        "description": "FSD is used in your company?"
+    },
+    "pages.home.companies.tell_us": {
+        "message": "Hãy cho chúng tôi biết",
+        "description": "Tell us"
+    },
+    "pages.examples.title": {
+        "message": "Ví dụ",
+        "description": "Page title"
+    },
+    "pages.examples.subtitle": {
+        "message": "Danh sách các website được xây dựng với Feature-Sliced Design",
+        "description": "Page subtitle"
+    },
+    "pages.versions.title": {
+        "message": "Các phiên bản Feature-Sliced Design",
+        "description": "Feature-Sliced Design versions"
+    },
+    "pages.versions.current": {
+        "message": "Tài liệu cho phiên bản hiện tại có thể tìm thấy ở đây",
+        "description": "Description for current version"
+    },
+    "pages.versions.legacy": {
+        "message": "Tài liệu cho các phiên bản cũ của {of} có thể tìm thấy ở đây ",
+        "description": "Description for legacy version"
+    },
+    "pages.nav.title": {
+        "message": "🧭 Điều hướng",
+        "description": "NavPage title"
+    },
+    "pages.nav.legacy.title": {
+        "message": "Route cũ",
+        "description": "NavPage section=legacy title"
+    },
+    "pages.nav.legacy.details": {
+        "message": "Sau khi tái cấu trúc tài liệu, một số route đã thay đổi. Bên dưới bạn có thể tìm thấy trang mà bạn đang tìm kiếm.",
+        "description": "NavPage section=legacy details"
+    },
+    "pages.nav.legacy.subdetails": {
+        "message": "Nhưng có redirect từ các link cũ để đảm bảo tương thích",
+        "description": "NavPage section=legacy subdetails"
+    },
+    "features.feedback-badge.label": {
+        "message": "Chia sẻ phản hồi của bạn về tài liệu 🤙",
+        "description": "Feedback share button label"
+    },
+    "features.feedback-badge.url": {
+        "message": "https://forms.gle/nsYua6bMMG5iBB3v7",
+        "description": "Feedback share form url"
+    },
+    "features.feedback-doc.button-text": {
+        "message": "Phản hồi",
+        "description": "The text on a floating button to leave feedback about the docs"
+    },
+    "features.feedback-doc.email-placeholder": {
+        "message": "Email của bạn (tùy chọn)",
+        "description": "The placeholder for email input"
+    },
+    "features.feedback-doc.error-message": {
+        "message": "Đã xảy ra lỗi. Vui lòng thử lại sau.",
+        "description": "The error message displayed when feedback form submission fails"
+    },
+    "features.feedback-doc.modal-title-error-403": {
+        "message": "URL request không khớp với URL được định nghĩa trong PushFeedback cho project này.",
+        "description": "The title of the modal displayed when feedback form submission fails with 403 error"
+    },
+    "features.feedback-doc.modal-title-error-404": {
+        "message": "Chúng tôi không tìm thấy project id được cung cấp trong PushFeedback.",
+        "description": "The title of the modal displayed when feedback form submission fails with 404 error"
+    },
+    "features.feedback-doc.message-placeholder": {
+        "message": "Nhận xét",
+        "description": "The placeholder for message input"
+    },
+    "features.feedback-doc.modal-title": {
+        "message": "Chia sẻ phản hồi của bạn",
+        "description": "The title of the modal to leave feedback about the docs"
+    },
+    "features.feedback-doc.modal-title-error": {
+        "message": "Oops!",
+        "description": "The title of the modal displayed when feedback form submission fails"
+    },
+    "features.feedback-doc.modal-title-success": {
+        "message": "Cảm ơn phản hồi của bạn!",
+        "description": "The title of the modal displayed when feedback form submission succeeds"
+    },
+    "features.feedback-doc.screenshot-button-text": {
+        "message": "Chụp Screenshot",
+        "description": "The text on a button to take a screenshot"
+    },
+    "features.feedback-doc.screenshot-topbar-text": {
+        "message": "CHỌN MỘT ELEMENT TRÊN TRANG",
+        "description": "The text displayed in the top bar when selecting an element to take a screenshot"
+    },
+    "features.feedback-doc.send-button-text": {
+        "message": "Gửi",
+        "description": "The text on a button to send feedback"
+    },
+    "features.feedback-doc.rating-placeholder": {
+        "message": "Trang này có hữu ích không?",
+        "description": "The placeholder for rating input"
+    },
+    "features.feedback-doc.rating-stars-placeholder": {
+        "message": "Bạn đánh giá trang này như thế nào",
+        "description": "The placeholder for rating stars input"
+    },
+    "features.hero.tagline": {
+        "message": "Phương pháp luận kiến trúc cho các dự án frontend",
+        "description": "Architectural methodology for frontend projects"
+    },
+    "features.hero.get_started": {
+        "message": "Bắt đầu",
+        "description": "Get Started"
+    },
+    "features.hero.examples": {
+        "message": "Ví dụ",
+        "description": "Examples"
+    },
+    "features.hero.previous": {
+        "message": "Phiên bản trước",
+        "description": "Previous version"
+    },
+    "shared.wip.title": {
+        "message": "Bài viết đang trong quá trình hoàn thiện",
+        "description": "Admonition title"
+    },
+    "shared.wip.subtitle": {
+        "message": "Để đẩy nhanh việc phát hành bài viết, bạn có thể:",
+        "description": "Admonition subtitle"
+    },
+    "shared.wip.var.feedback.base": {
+        "message": "📢 Chia sẻ phản hồi của bạn ",
+        "description": "Variant for contribute (base)"
+    },
+    "shared.wip.var.feedback.link": {
+        "message": "tại bài viết (comment/emoji-reaction)",
+        "description": "Variant for contribute (link)"
+    },
+    "shared.wip.var.material.base": {
+        "message": "💬 Thu thập tài liệu liên quan ",
+        "description": "Variant for contribute (base)"
+    },
+    "shared.wip.var.material.link": {
+        "message": "về chủ đề từ chat",
+        "description": "Variant for contribute (link)"
+    },
+    "shared.wip.var.contribute.base": {
+        "message": "⚒️ Đóng góp ",
+        "description": "Variant for contribute (base)"
+    },
+    "shared.wip.var.contribute.link": {
+        "message": "bằng bất kỳ cách nào khác",
+        "description": "Variant for contribute (link)"
+    },
+    "theme.NotFound.title": {
+        "message": "Không tìm thấy trang",
+        "description": "The title of the 404 page"
+    },
+    "theme.NotFound.p1": {
+        "message": "Chúng tôi không thể tìm thấy nội dung bạn đang tìm kiếm.",
+        "description": "The first paragraph of the 404 page"
+    },
+    "theme.NotFound.p2": {
+        "message": "Vui lòng liên hệ với chủ sở hữu của trang đã link bạn đến URL gốc và cho họ biết link đã bị hỏng.",
+        "description": "The 2nd paragraph of the 404 page"
+    },
+    "theme.AnnouncementBar.closeButtonAriaLabel": {
+        "message": "Đóng",
+        "description": "The ARIA label for close button of announcement bar"
+    },
+    "theme.blog.paginator.navAriaLabel": {
+        "message": "Điều hướng trang danh sách blog",
+        "description": "The ARIA label for the blog pagination"
+    },
+    "theme.blog.paginator.newerEntries": {
+        "message": "Bài mới hơn",
+        "description": "The label used to navigate to the newer blog posts page (previous page)"
+    },
+    "theme.blog.paginator.olderEntries": {
+        "message": "Bài cũ hơn",
+        "description": "The label used to navigate to the older blog posts page (next page)"
+    },
+    "theme.blog.post.readingTime.plurals": {
+        "message": "1 phút đọc | {readingTime} phút đọc",
+        "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+    },
+    "theme.tags.tagsListLabel": {
+        "message": "Tags:",
+        "description": "The label alongside a tag list"
+    },
+    "theme.blog.post.readMore": {
+        "message": "Đọc thêm",
+        "description": "The label used in blog post item excerpts to link to full blog posts"
+    },
+    "theme.blog.post.paginator.navAriaLabel": {
+        "message": "Điều hướng trang blog post",
+        "description": "The ARIA label for the blog posts pagination"
+    },
+    "theme.blog.post.paginator.newerPost": {
+        "message": "Bài mới hơn",
+        "description": "The blog post button label to navigate to the newer/previous post"
+    },
+    "theme.blog.post.paginator.olderPost": {
+        "message": "Bài cũ hơn",
+        "description": "The blog post button label to navigate to the older/next post"
+    },
+    "theme.tags.tagsPageTitle": {
+        "message": "Tags",
+        "description": "The title of the tag list page"
+    },
+    "theme.blog.post.plurals": {
+        "message": "Một bài viết|{count} bài viết",
+        "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+    },
+    "theme.blog.tagTitle": {
+        "message": "{nPosts} được tag với \"{tagName}\"",
+        "description": "The title of the page for a blog tag"
+    },
+    "theme.tags.tagsPageLink": {
+        "message": "Xem tất cả Tags",
+        "description": "The label of the link targeting the tag list page"
+    },
+    "theme.CodeBlock.copyButtonAriaLabel": {
+        "message": "Copy code vào clipboard",
+        "description": "The ARIA label for copy code blocks button"
+    },
+    "theme.CodeBlock.copied": {
+        "message": "Đã copy",
+        "description": "The copied button label on code blocks"
+    },
+    "theme.CodeBlock.copy": {
+        "message": "Copy",
+        "description": "The copy button label on code blocks"
+    },
+    "theme.docs.sidebar.expandButtonTitle": {
+        "message": "Mở rộng sidebar",
+        "description": "The ARIA label and title attribute for expand button of doc sidebar"
+    },
+    "theme.docs.sidebar.expandButtonAriaLabel": {
+        "message": "Mở rộng sidebar",
+        "description": "The ARIA label and title attribute for expand button of doc sidebar"
+    },
+    "theme.docs.paginator.navAriaLabel": {
+        "message": "Điều hướng trang docs",
+        "description": "The ARIA label for the docs pagination"
+    },
+    "theme.docs.paginator.previous": {
+        "message": "Trước",
+        "description": "The label used to navigate to the previous doc"
+    },
+    "theme.docs.paginator.next": {
+        "message": "Tiếp",
+        "description": "The label used to navigate to the next doc"
+    },
+    "theme.docs.sidebar.collapseButtonTitle": {
+        "message": "Thu gọn sidebar",
+        "description": "The title attribute for collapse button of doc sidebar"
+    },
+    "theme.docs.sidebar.collapseButtonAriaLabel": {
+        "message": "Thu gọn sidebar",
+        "description": "The title attribute for collapse button of doc sidebar"
+    },
+    "theme.docs.sidebar.responsiveCloseButtonLabel": {
+        "message": "Đóng menu",
+        "description": "The ARIA label for close button of mobile doc sidebar"
+    },
+    "theme.docs.sidebar.responsiveOpenButtonLabel": {
+        "message": "Mở menu",
+        "description": "The ARIA label for open button of mobile doc sidebar"
+    },
+    "theme.docs.versions.unreleasedVersionLabel": {
+        "message": "Đây là tài liệu chưa phát hành cho {siteTitle} phiên bản {versionLabel}.",
+        "description": "The label used to tell the user that he's browsing an unreleased doc version"
+    },
+    "theme.docs.versions.unmaintainedVersionLabel": {
+        "message": "Đây là tài liệu cho {siteTitle} {versionLabel}, không còn được maintain tích cực.",
+        "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+    },
+    "theme.docs.versions.latestVersionSuggestionLabel": {
+        "message": "Để xem tài liệu cập nhật, xem {latestVersionLink} ({versionLabel}).",
+        "description": "The label userd to tell the user that he's browsing an unmaintained doc version"
+    },
+    "theme.docs.versions.latestVersionLinkLabel": {
+        "message": "phiên bản mới nhất",
+        "description": "The label used for the latest version suggestion link label"
+    },
+    "theme.common.editThisPage": {
+        "message": "Sửa trang này",
+        "description": "The link label to edit the current page"
+    },
+    "theme.common.headingLinkTitle": {
+        "message": "Link trực tiếp đến heading",
+        "description": "Title for link to heading"
+    },
+    "theme.lastUpdated.atDate": {
+        "message": " vào {date}",
+        "description": "The words used to describe on which date a page has been last updated"
+    },
+    "theme.lastUpdated.byUser": {
+        "message": " bởi {user}",
+        "description": "The words used to describe by who the page has been last updated"
+    },
+    "theme.lastUpdated.lastUpdatedAtBy": {
+        "message": "Cập nhật lần cuối{atDate}{byUser}",
+        "description": "The sentence used to display when a page has been last updated, and by who"
+    },
+    "theme.common.skipToMainContent": {
+        "message": "Chuyển đến nội dung chính",
+        "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+    }
+}

--- a/i18n/vi/docusaurus-plugin-content-docs/community/index.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/community/index.mdx
@@ -1,0 +1,40 @@
+---
+hide_table_of_contents: true
+---
+
+# 💫 Cộng đồng
+
+<p class="summary">
+Tài nguyên cộng đồng, tài liệu bổ sung
+</p>
+
+## Chính
+
+import NavCard from "@site/src/shared/ui/nav-card/tmpl.mdx"
+import { StarOutlined, SearchOutlined, TeamOutlined, VerifiedOutlined } from "@ant-design/icons";
+
+<NavCard
+    title="Tài nguyên tuyệt vời" 
+    description="Danh sách tuyển chọn các video, bài viết, package FSD tuyệt vời"
+    to="https://github.com/feature-sliced/awesome"
+    Icon={StarOutlined}
+/>
+<NavCard
+    title="Đội ngũ" 
+    description="Đội ngũ cốt lõi, Nhà vô địch, Người đóng góp, Công ty"
+    to="/community/team"
+    Icon={TeamOutlined}
+/>
+<NavCard
+    title="Brandbook" 
+    description="Khuyến nghị sử dụng thương hiệu FSD"
+    to="/docs/branding"
+    Icon={VerifiedOutlined}
+/>
+<NavCard
+    title="Đóng góp" 
+    description="Hướng dẫn, Quy trình làm việc, Hỗ trợ"
+    to="#"
+    Icon={SearchOutlined}
+    disabled
+/>

--- a/i18n/vi/docusaurus-plugin-content-docs/community/team.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/community/team.mdx
@@ -1,0 +1,18 @@
+---
+sidebar_class_name: sidebar-item--wip
+sidebar_position: 2
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Đội ngũ
+
+<WIP ticket="192" />
+
+## Đội ngũ cốt lõi
+
+### Nhà vô địch
+
+## Người đóng góp
+
+## Công ty

--- a/i18n/vi/docusaurus-plugin-content-docs/current.json
+++ b/i18n/vi/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,38 @@
+{
+    "version.label": {
+        "message": "v2.1",
+        "description": "The label for version current"
+    },
+    "sidebar.getstartedSidebar.category.Tutorials": {
+        "message": "Hướng dẫn",
+        "description": "The label for category Tutorials in sidebar getstartedSidebar"
+    },
+    "sidebar.aboutSidebar.category.Alternatives": {
+        "message": "Giải pháp thay thế",
+        "description": "The label for category Alternatives in sidebar aboutSidebar"
+    },
+    "sidebar.aboutSidebar.category.Promote": {
+        "message": "Quảng bá",
+        "description": "The label for category Promote in sidebar aboutSidebar"
+    },
+    "sidebar.guidesSidebar.category.Examples": {
+        "message": "Ví dụ",
+        "description": "The label for category Examples in sidebar guidesSidebar"
+    },
+    "sidebar.guidesSidebar.category.Migration": {
+        "message": "Migration",
+        "description": "The label for category Migration in sidebar guidesSidebar"
+    },
+    "sidebar.guidesSidebar.category.Tech": {
+        "message": "Tech",
+        "description": "The label for category Tech in sidebar guidesSidebar"
+    },
+    "sidebar.conceptsSidebar.category.Issues": {
+        "message": "Vấn đề",
+        "description": "The label for category Issues in sidebar conceptsSidebar"
+    },
+    "sidebar.referenceSidebar.category.Layer": {
+        "message": "Layer",
+        "description": "The label for category Layer in sidebar referenceSidebar"
+    }
+}

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/alternatives.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/alternatives.mdx
@@ -1,0 +1,153 @@
+---
+sidebar_class_name: sidebar-item--wip
+sidebar_position: 3
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Các phương án thay thế
+
+<WIP ticket="62" />
+
+Lịch sử các cách tiếp cận kiến trúc
+
+## Big Ball of Mud
+
+<WIP ticket="258" />
+
+> Nó là gì; Tại sao nó phổ biến; Khi nào nó bắt đầu mang lại vấn đề; Phải làm gì và FSD giúp đỡ đây như thế nào
+
+- [(Article) Oleg Isonen - Last words on UI architecture before an AI takes over](https://oleg008.medium.com/last-words-on-ui-architecture-before-an-ai-takes-over-468c78f18f0d)
+- [(Report) Julia Nikolaeva, iSpring - Big Ball of Mud and other problems of the monolith, we have handled](http://youtu.be/gna4Ynz1YNI)
+- [(Article) DD - Big Ball of mud](https://thedomaindrivendesign.io/big-ball-of-mud/)
+
+
+## Smart & Dumb components
+
+<WIP ticket="214" />
+
+> Về cách tiếp cận; Về khả năng áp dụng trong frontend; Vị trí của methodology
+
+Về sự lỗi thời, về quan điểm mới từ methodology
+
+Tại sao cách tiếp cận component-container lại xấu?
+
+- [(Article) Den Abramov-Presentation and Container Components (TLDR: deprecated)](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0)
+
+
+## Design Principles
+
+<WIP ticket="59" />
+
+> Chúng ta đang nói về điều gì; Vị trí của FSD
+
+SOLID, GRASP, KISS, YAGNI, ... - và tại sao chúng không hoạt động tốt cùng nhau trong thực tế
+
+Và nó tổng hợp các thực hành này như thế nào
+
+- [(Talk) Ilya Azin - Feature-Sliced Design (fragment about Design Principles)](https://youtu.be/SnzPAr_FJ7w?t=380)
+
+
+## DDD
+
+<WIP ticket="1" />
+
+> Về cách tiếp cận; Tại sao nó hoạt động kém trong thực tế
+
+Sự khác biệt là gì, nó cải thiện khả năng áp dụng như thế nào, nó áp dụng các thực hành ở đâu
+
+- [(Article) DDD, Hexagonal, Onion, Clean, CQRS, ... How I put it all together](https://herbertograca.com/2017/11/16/explicit-architecture-01-ddd-hexagonal-onion-clean-cqrs-how-i-put-it-all-together/)
+- [(Talk) Ilya Azin - Feature-Sliced Design (fragment about Clean Architecture, DDD)](https://youtu.be/SnzPAr_FJ7w?t=528)
+
+
+## Clean Architecture
+
+<WIP ticket="165" />
+
+> Về cách tiếp cận; Về khả năng áp dụng trong frontend; Vị trí của FSD
+
+Chúng giống nhau như thế nào (đối với nhiều người), chúng khác nhau như thế nào
+
+- [(Thread) About use-case/interactor in the methodology](https://t.me/feature_sliced/3897)
+- [(Thread) About DI in the methodology](https://t.me/feature_sliced/4592)
+- [(Article) Alex Bespoyasov - Clean Architecture on frontend](https://bespoyasov.me/blog/clean-architecture-on-frontend/)
+- [(Article) DDD, Hexagonal, Onion, Clean, CQRS, ... How I put it all together](https://herbertograca.com/2017/11/16/explicit-architecture-01-ddd-hexagonal-onion-clean-cqrs-how-i-put-it-all-together/)
+- [(Talk) Ilya Azin - Feature-Sliced Design (fragment about Clean Architecture, DDD)](https://youtu.be/SnzPAr_FJ7w?t=528)
+- [(Article) Misconceptions of Clean Architecture](http://habr.com/ru/company/mobileup/blog/335382/)
+
+
+## Frameworks
+
+<WIP ticket="58" />
+
+> Về khả năng áp dụng trong frontend; Tại sao các framework không giải quyết vấn đề; tại sao không có cách tiếp cận duy nhất; vị trí của FSD
+
+Không phụ thuộc vào framework, cách tiếp cận thông thường
+
+- [(Article) About the reasons for creating the methodology (fragment about frameworks)](/docs/about/motivation)
+- [(Thread) About the applicability of the methodology for different frameworks](https://t.me/feature_sliced/3867)
+
+
+## Atomic Design
+
+### Nó là gì?
+Trong Atomic Design, phạm vi trách nhiệm được chia thành các layer tiêu chuẩn.
+
+Atomic Design được chia thành **5 layer** (từ trên xuống dưới):
+
+1. `pages` - Chức năng tương tự với layer `pages` trong FSD.
+2. `templates` - Các component xác định cấu trúc của trang mà không gắn với nội dung cụ thể.
+3. `organisms` - Các module bao gồm các molecule và có logic kinh doanh.
+4. `molecules` - Các component phức tạp hơn nói chung không chứa logic kinh doanh.
+5. `atoms` - Các component UI không có logic kinh doanh.
+
+Các module ở một layer chỉ tương tác với các module ở các layer bên dưới, tương tự như FSD.
+Tức là, các molecule được xây dựng từ các atom, các organism từ các molecule, các template từ các organism, và các page từ các template.
+Atomic Design cũng bao hàm việc sử dụng Public API trong các module để cô lập.
+
+### Khả năng áp dụng cho frontend
+
+Atomic Design tương đối phổ biến trong các dự án. Atomic Design phổ biến hơn trong các nhà thiết kế web hơn là trong phát triển.
+Các nhà thiết kế web thường sử dụng Atomic Design để tạo ra các thiết kế có thể mở rộng và dễ bảo trì.
+Trong phát triển, Atomic Design thường được trộn lẫn với các methodology kiến trúc khác.
+
+Tuy nhiên, vì Atomic Design tập trung vào các component UI và sự kết hợp của chúng, một vấn đề phát sinh với việc triển khai
+logic kinh doanh trong kiến trúc.
+
+Vấn đề là Atomic Design không cung cấp một mức trách nhiệm rõ ràng cho logic kinh doanh,
+dẫn đến việc phân tán nó qua các component và mức khác nhau, làm phức tạp hóa bảo trì và testing.
+Logic kinh doanh trở nên mờ nhạt, khiến việc phân tách rõ trách nhiệm trở nên khó khăn và làm
+code ít modular và có thể tái sử dụng hơn.
+
+### Nó liên quan đến FSD như thế nào?
+
+Trong bối cảnh của FSD, một số yếu tố của Atomic Design có thể được áp dụng để tạo ra các component UI linh hoạt và có thể mở rộng.
+Các layer `atoms` và `molecules` có thể được triển khai trong `shared/ui` trong FSD, đơn giản hóa việc tái sử dụng và
+bảo trì các yếu tố UI cơ bản.
+
+```
+├── shared
+│   ├── ui
+│   │   ├── atoms
+│   │   ├── molecules
+│   ...
+```
+So sánh FSD và Atomic Design cho thấy rằng cả hai methodology đều hướng tới tính modular và tái sử dụng
+nhưng tập trung vào các khía cạnh khác nhau. Atomic Design hướng tới các component trực quan và sự kết hợp của chúng.
+FSD tập trung vào việc chia chức năng của ứng dụng thành các module độc lập và các kết nối giữa chúng.
+
+- [Atomic Design Methodology](https://atomicdesign.bradfrost.com/table-of-contents/)
+- [(Thread) About applicability in shared / ui](https://t.me/feature_sliced/1653)
+- [(Video) Briefly about Atomic Design](https://youtu.be/Yi-A20x2dcA)
+- [(Talk) Ilya Azin - Feature-Sliced Design (fragment about Atomic Design)](https://youtu.be/SnzPAr_FJ7w?t=587)
+
+## Feature Driven
+
+<WIP ticket="219" />
+
+> Về cách tiếp cận; Về khả năng áp dụng trong frontend; Vị trí của FSD
+
+Về tính tương thích, phát triển lịch sử và so sánh
+
+- [(Talk) Oleg Isonen - Feature Driven Architecture](https://youtu.be/BWAeYuWFHhs)
+- [Feature Driven-Short specification (from the point of view of FSD)](https://github.com/feature-sliced/documentation/tree/rc/feature-driven)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/mission.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/mission.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 1
+---
+
+# Sứ mệnh
+
+Ở đây chúng tôi mô tả các mục tiêu và hạn chế của khả năng áp dụng của phương pháp - những gì chúng tôi được hướng dẫn khi phát triển phương pháp
+
+- Chúng tôi xem mục tiêu của mình là sự cân bằng giữa ideology và tính đơn giản
+- Chúng tôi sẽ không thể tạo ra một giải pháp vạn năng phù hợp với mọi người
+
+**Tuy nhiên, phương pháp này nên gần gũi và dễ tiếp cận cho một nhóm rộng rãi các developer**
+
+## Mục tiêu
+
+### Tính rõ ràng trực quan cho nhiều developer
+
+Phương pháp này nên dễ tiếp cận - cho hầu hết thành viên trong nhóm dự án
+
+*Vì ngay cả với tất cả các công cụ tương lai, nó sẽ không đủ, nếu chỉ có những senior/lead có kinh nghiệm hiểu được phương pháp*
+
+### Giải quyết các vấn đề hàng ngày
+
+Phương pháp này nên đưa ra các lý do và giải pháp cho các vấn đề hàng ngày của chúng ta khi phát triển dự án
+
+**Và cũng - gắn kèm công cụ vào tất cả những điều này (cli, linter)**
+
+Để các developer có thể sử dụng một cách tiếp cận *đã được kiểm nghiệm trong thực chiến* cho phép họ bỏ qua các vấn đề lâu dài về kiến trúc và phát triển
+
+> *@sergeysova: Hãy tưởng tượng rằng, một developer viết code trong khuôn khổ của phương pháp và gặp vấn đề ít hơn 10 lần, đơn giản vì những người khác đã nghĩ ra giải pháp cho nhiều vấn đề.*
+
+## Hạn chế
+
+Chúng tôi không muốn *ép buộc quan điểm của mình*, và đồng thời chúng tôi hiểu rằng *nhiều thói quen của chúng ta, với tư cách là developer, cản trở từ ngày này qua ngày khác*
+
+Mọi người đều có mức độ kinh nghiệm riêng trong việc thiết kế và phát triển hệ thống, **do đó, đáng làm hiểu những điều sau:**
+
+- **Sẽ không hoạt động**: rất đơn giản, rất rõ ràng, cho mọi người
+    > *@sergeysova: Một số khái niệm không thể được hiểu một cách trực quan cho đến khi bạn gặp phải vấn đề và dành nhiều năm để giải quyết chúng.*
+    >
+    > - *Trong thế giới toán học: là graph theory.*
+    > - *Trong vật lý: cơ học lượng tử.*
+    > - *Trong lập trình: kiến trúc ứng dụng.*
+
+- **Có thể và mong muốn**: tính đơn giản, khả năng mở rộng
+
+## Xem thêm
+
+- [Các vấn đề kiến trúc][refs-architecture--problems]
+
+[refs-architecture--problems]: /docs/about/understanding/architecture#problems

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/motivation.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/motivation.md
@@ -1,0 +1,148 @@
+---
+sidebar_position: 2
+---
+
+# Động lực
+
+Ý tưởng chính của **Feature-Sliced Design** là tạo điều kiện thuận lợi và giảm chi phí phát triển các dự án phức tạp và được phát triển, dựa trên việc [kết hợp kết quả nghiên cứu, thảo luận kinh nghiệm của các loại developer khác nhau trong phạm vi rộng][ext-discussions].
+
+Hiển nhiên, đây sẽ không phải là giải pháp vạn năng, và tất nhiên, phương pháp này sẽ có [giới hạn khả năng áp dụng][refs-mission] riêng của mình.
+
+Tuy nhiên, có những câu hỏi hợp lý về *tính khả thi của một phương pháp như vậy nói chung*
+
+:::note
+
+Chi tiết hơn [được thảo luận trong cuộc thảo luận][disc-src]
+
+:::
+
+## Tại sao các giải pháp hiện có không đủ?
+<!--TODO: #existing-solutions -->
+> Thường là những lập luận này:
+>
+> - *"Tại sao bạn cần một methodology mới, khi đã có những phương pháp và nguyên tắc thiết kế lâu đời như `SOLID`, `KISS`, `YAGNI`, `DDD`, `GRASP`, `DRY`, v.v."*
+> - *"Tất cả các vấn đề được giải quyết bằng tài liệu dự án tốt, test và quy trình có cấu trúc"*
+> - *"Các vấn đề sẽ không xảy ra nếu tất cả developer đều tuân theo những điều trên"*
+> - *"Mọi thứ đã được phát minh trước bạn, bạn chỉ không biết sử dụng nó"*
+> - *"Hãy lấy \{FRAMEWORK_NAME\} - mọi thứ đã được quyết định sẵn cho bạn ở đó"*
+
+### Chỉ có nguyên tắc là chưa đủ
+
+**Việc tồn tại các nguyên tắc là chưa đủ để thiết kế một kiến trúc tốt**
+
+Không phải ai cũng biết chúng một cách hoàn toàn, thậm chí ít người hơn hiểu và áp dụng chúng một cách chính xác
+
+*Các nguyên tắc thiết kế quá chung chung, và không đưa ra câu trả lời cụ thể cho câu hỏi: "Làm thế nào để thiết kế cấu trúc và kiến trúc của một ứng dụng có thể mở rộng và linh hoạt?"*
+
+### Quy trình không phải lúc nào cũng hiệu quả
+
+*Tài liệu/Test/Quy trình* tất nhiên là tốt, nhưng tiếc thay, ngay cả với chi phí cao cho chúng - **chúng không phải lúc nào cũng giải quyết được các vấn đề do kiến trúc đặt ra và việc đưa người mới vào dự án**
+
+- Thời gian để mỗi developer tham gia vào dự án không được giảm đáng kể, bởi vì tài liệu thường sẽ trở nên khổng lồ / lỗi thời
+- Liên tục đảm bảo rằng mọi người hiểu kiến trúc theo cùng một cách - điều này cũng đòi hỏi một lượng tài nguyên khổng lồ
+- Đừng quên về bus-factor
+
+### Các framework hiện có không thể áp dụng ở mọi nơi
+
+- Các giải pháp hiện có thường có ngưỡng vào cao, điều này khiến việc tìm kiếm developer mới trở nên khó khăn
+- Ngoài ra, phần lớn thời gian, việc lựa chọn công nghệ đã được xác định trước khi các vấn đề nghiêm trọng trong dự án xuất hiện, và do đó bạn cần có khả năng "làm việc với những gì có sẵn" - **mà không bị ràng buộc vào công nghệ**
+
+> Q: *"Trong dự án của tôi `React/Vue/Redux/Effector/Mobx/{YOUR_TECH}` - làm thế nào tôi có thể xây dựng tốt hơn cấu trúc của các entity và mối quan hệ giữa chúng?"*
+
+### Kết quả
+
+Chúng ta nhận được các dự án *"độc đáo như bông tuyết"*, mỗi dự án đều đòi hỏi nhân viên phải học hỏi lâu dài, và kiến thức không chắc có thể áp dụng được cho dự án khác
+
+> @sergeysova: *"Đây chính xác là tình huống hiện tại tồn tại trong lĩnh vực phát triển frontend của chúng ta: mỗi lead sẽ phát minh ra các kiến trúc và cấu trúc dự án khác nhau, trong khi không chắc rằng những cấu trúc này sẽ vượt qua được thử thách thời gian, kết quả là tối đa hai người có thể phát triển dự án ngoài anh ta, và mỗi developer mới cần phải được hướng dẫn lại từ đầu."*
+
+## Tại sao các developer cần methodology?
+
+### Tập trung vào các tính năng kinh doanh, không phải vấn đề kiến trúc
+
+Methodology cho phép bạn tiết kiệm tài nguyên trong việc thiết kế một kiến trúc có thể mở rộng và linh hoạt, thay vào đó hướng sự chú ý của các developer vào việc phát triển chức năng chính. Đồng thời, các giải pháp kiến trúc được tiêu chuẩn hóa từ dự án này sang dự án khác.
+
+*Một câu hỏi riêng là methodology nên giành được sự tin tưởng của cộng đồng, để một developer khác có thể làm quen với nó và dựa vào nó trong việc giải quyết các vấn đề của dự án trong thời gian có sẵn*
+
+### Giải pháp đã được kiểm chứng bằng kinh nghiệm
+
+Methodology được thiết kế cho các developer hướng tới *một giải pháp đã được chứng minh cho việc thiết kế logic kinh doanh phức tạp*
+
+*Tuy nhiên, rõ ràng là methodology nói chung là về một tập hợp các best-practice, bài viết giải quyết các vấn đề và trường hợp nhất định trong quá trình phát triển. Do đó, methodology cũng sẽ hữu ích cho các developer khác - những người bằng cách nào đó gặp phải vấn đề trong quá trình phát triển và thiết kế*
+
+### Sức khỏe dự án
+
+Methodology sẽ cho phép *giải quyết và theo dõi các vấn đề của dự án trước, mà không đòi hỏi một lượng lớn tài nguyên*
+
+**Phần lớn thời gian, nợ kỹ thuật tích tụ và tích tụ theo thời gian, và trách nhiệm giải quyết nó nằm ở cả lead và team**
+
+Methodology sẽ cho phép bạn *cảnh báo* trước các vấn đề có thể xảy ra trong việc mở rộng và phát triển dự án
+
+## Tại sao doanh nghiệp cần một methodology?
+
+### Onboarding nhanh chóng
+
+Với methodology, bạn có thể thuê một người vào dự án **đã quen thuộc với cách tiếp cận này trước đó, và không cần đào tạo lại**
+
+*Mọi người bắt đầu hiểu và đóng góp cho dự án nhanh hơn, và có thêm bảo đảm để tìm người cho các lần lặp tiếp theo của dự án*
+
+### Giải pháp đã được kiểm chứng bằng kinh nghiệm
+
+Với methodology, doanh nghiệp sẽ có *giải pháp cho hầu hết các vấn đề phát sinh trong quá trình phát triển hệ thống*
+
+Vì phần lớn thời gian doanh nghiệp muốn có một framework / giải pháp có thể giải quyết phần lớn các vấn đề trong quá trình phát triển dự án
+
+### Khả năng áp dụng cho các giai đoạn khác nhau của dự án
+
+Methodology có thể mang lại lợi ích cho dự án *cả ở giai đoạn hỗ trợ và phát triển dự án, và ở giai đoạn MVP*
+
+Vâng, điều quan trọng nhất đối với MVP là *"các tính năng, không phải kiến trúc được đặt nền cho tương lai"*. Nhưng ngay cả trong điều kiện deadline hạn chế, việc biết các best-practice từ methodology, bạn có thể *"làm với ít máu"*, khi thiết kế phiên bản MVP của hệ thống, tìm ra một sự thỏa hiệp hợp lý
+(thay vì mô hình hóa các tính năng "một cách ngẫu nhiên")
+
+*Điều tương tự có thể nói về testing*
+
+## Khi nào methodology của chúng tôi không cần thiết?
+
+- Nếu dự án sẽ tồn tại trong thời gian ngắn
+- Nếu dự án không cần kiến trúc được hỗ trợ
+- Nếu doanh nghiệp không nhận thấy mối liên kết giữa code base và tốc độ phát triển tính năng
+- Nếu đối với doanh nghiệp việc đóng các đơn hàng càng sớm càng tốt, mà không cần hỗ trợ thêm
+
+### Qôy mô doanh nghiệp
+
+- **Doanh nghiệp nhỏ** - thường cần một giải pháp có sẵn và rất nhanh. Chỉ khi doanh nghiệp phát triển (ít nhất là gần trung bình), họ mới hiểu rằng để khách hàng tiếp tục sử dụng, cần thiết, trong số những điều khác, là dành thời gian cho chất lượng và tính ổn định của các giải pháp đang được phát triển
+- **Doanh nghiệp vừa** - thường hiểu tất cả các vấn đề của phát triển, và ngay cả khi cần thiết *"đua tốc để có các tính năng"*, họ vẫn dành thời gian cho việc cải thiện chất lượng, refactoring và test (và tất nhiên - cho kiến trúc có thể mở rộng)
+- **Doanh nghiệp lớn** - thường đã có đối tượng rộng rãi, nhân sự, và một tập hợp các thực hành rộng rãi hơn nhiều, và có thể thậm chí có cách tiếp cận kiến trúc riêng của họ, nên ý tưởng sử dụng của người khác không đến với họ thường xuyên
+
+## Kế hoạch
+
+Phần chính của các mục tiêu [được trình bày ở đây][refs-mission--goals], nhưng ngoài ra, đáng nói về kỳ vọng của chúng tôi từ methodology trong tương lai
+
+### Kết hợp kinh nghiệm
+
+Hiện tại chúng tôi đang cố gắng kết hợp tất cả kinh nghiệm đa dạng của `core-team`, và có được một methodology được rèn luyện bằng thực hành
+
+Tất nhiên, kết quả có thể là Angular 3.0, nhưng quan trọng hơn ở đây là **nghiên cứu chính vấn đề thiết kế kiến trúc của các hệ thống phức tạp**
+
+*Và vâng - chúng tôi có phàn nàn về phiên bản hiện tại của methodology, nhưng chúng tôi muốn làm việc cùng nhau để đi đến một giải pháp duy nhất và tối ưu (tính đến, trong số những điều khác, kinh nghiệm của cộng đồng)*
+
+### Cuộc sống ngoài specification
+
+Nếu mọi thứ điễn ra tốt, thì methodology sẽ không chỉ giới hạn trong specification và toolkit
+
+- Có thể sẽ có báo cáo, bài viết
+- Có thể có `CODE_MOD` cho việc migration sang các công nghệ khác của các dự án được viết theo methodology
+- Có thể kết quả là chúng ta sẽ có thể tiếp cận được các maintainer của các giải pháp công nghệ lớn
+  - *Đặc biệt cho React, so với các framework khác - đây là vấn đề chính, vì nó không nói cách giải quyết những vấn đề nhất định*
+
+## Xem thêm
+
+- [(Thảo luận) Không cần methodology?][disc-src]
+- [Về sứ mệnh của methodology: mục tiêu và giới hạn][refs-mission]
+- [Các loại kiến thức trong dự án][refs-knowledge]
+
+[refs-mission]: /docs/about/mission
+[refs-mission--goals]: /docs/about/mission#goals
+[refs-knowledge]: /docs/about/understanding/knowledge-types
+
+[disc-src]: https://github.com/feature-sliced/documentation/discussions/27
+[ext-discussions]: https://github.com/feature-sliced/documentation/discussions

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/promote/_category_.yaml
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/promote/_category_.yaml
@@ -1,0 +1,3 @@
+label: Thúc đẩy
+position: 11
+collapsed: true

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/promote/for-company.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/promote/for-company.mdx
@@ -1,0 +1,18 @@
+---
+sidebar_position: 4
+sidebar_class_name: sidebar-item--wip
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Thúc đẩy trong công ty
+
+<WIP ticket="206" />
+
+## Dự án và công ty có cần methodology không?
+
+> Về việc chứng minh tính ứng dụng, Những nhiệm vụ đó
+
+## Làm thế nào để trình bày methodology cho doanh nghiệp?
+
+## Làm thế nào để chuẩn bị và chứng minh kế hoạch chuyển sang methodology?

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/promote/for-team.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/promote/for-team.mdx
@@ -1,0 +1,18 @@
+---
+sidebar_position: 3
+sidebar_class_name: sidebar-item--wip
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Thúc đẩy trong team
+
+<WIP ticket="182" />
+
+- Onboard những người mới
+- Hướng dẫn phát triển ("tìm kiếm module N ở đâu", v.v...)
+- Cách tiếp cận mới cho các task
+
+## Xem thêm
+- [(Thread) Sự đơn giản của các cách tiếp cận cũ và tầm quan trọng của sự tỉnh táo](https://t.me/feature_sliced/3360)
+- [(Thread) Về sự tiện lợi của việc tìm kiếm theo layer](https://t.me/feature_sliced/1918)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/promote/integration.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/promote/integration.mdx
@@ -1,0 +1,25 @@
+---
+sidebar_position: 1
+---
+
+# Các khía cạnh tích hợp
+
+## Tóm tắt
+
+5 phút đầu (RU):
+
+<iframe className="youtube" src="https://www.youtube.com/embed/TFA6zRO_Cl0?start=2110" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Ngoài ra
+
+**Ưu điểm**:
+- [Tổng quan](/docs/get-started/overview)
+- CodeReview
+- Onboarding
+
+
+**Nhược điểm:**
+- Độ phức tạp về mặt tư duy
+- Ngưỡng vào cao
+- "Layer hell"
+- Các vấn đề điển hình của các cách tiếp cận dựa trên feature

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/promote/partial-application.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/promote/partial-application.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 2
+sidebar_class_name: sidebar-item--wip
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Ứng dụng từng phần
+
+<WIP ticket="199" />
+
+> Làm thế nào để áp dụng methodology từng phần? Có hợp lý không? Nếu tôi bỏ qua thì sao?

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/_category_.yaml
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/_category_.yaml
@@ -1,0 +1,2 @@
+label: Hiểu biết
+position: 3

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/abstractions.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/abstractions.mdx
@@ -1,0 +1,26 @@
+---
+sidebar_position: 6
+sidebar_class_name: sidebar-item--wip
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Abstraction
+
+<WIP ticket="186" />
+
+## Quy luật của abstraction bị rò rỉ
+
+## Tại sao có quá nhiều abstraction
+
+> Abstraction giúp đối phó với độ phức tạp của dự án. Câu hỏi là - những abstraction này sẽ chỉ dành riêng cho dự án này, hay chúng ta sẽ cố gắng rút ra những abstraction chung dựa trên đặc thù của frontend
+
+> Kiến trúc và ứng dụng nói chung vốn phức tạp, và câu hỏi duy nhất là làm thế nào để phân phối và mô tả tốt hơn độ phức tạp này
+
+## Về phạm vi trách nhiệm
+
+> Về các abstraction tùy chọn
+
+## Xem thêm
+- [Về nhu cầu cho các layer mới](https://t.me/feature_sliced/2801)
+- [Về khó khăn trong việc hiểu methodology và các layer](https://t.me/feature_sliced/2619)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/architecture.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/architecture.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 1
+---
+
+# Về kiến trúc
+
+## Các vấn đề
+
+Thường thì cuộc trò chuyện về kiến trúc được nêng lên khi việc phát triển dừng lại do một số vấn đề nhất định trong dự án.
+
+### Bus-factor & Onboarding
+
+Chỉ có một số lượng hạn chế người hiểu dự án và kiến trúc của nó
+
+**Ví dụ:**
+
+- *"Khó đưa người vào phát triển"*
+- *"Đối với mọi vấn đề, mọi người đều có ý kiến riêng về cách giải quyết" (hãy ghen tị với angular)*
+- *"Tôi không hiểu chuyện gì đang xảy ra trong khối monolith lớn này"*
+
+### Hậu quả ngầm định và không kiểm soát được
+
+Nhiều tác dụng phụ ngầm định trong quá trình phát triển/refactoring *("tất cả đều phụ thuộc vào nhau")*
+
+**Ví dụ:**
+
+- *"Feature import feature"*
+- *"Tôi cập nhật store của một trang, và chức năng ở trang khác bị rơi"*
+- *"Logic bị tráng đầy khắp ứng dụng, và không thể theo dõi được đâu là đầu, đâu là cuối"*
+
+### Tái sử dụng logic không kiểm soát được
+
+Khó khăn trong việc tái sử dụng/sửa đổi logic hiện có
+
+Đồng thời, thường có [hai thái cực](https://github.com/feature-sliced/documentation/discussions/14):
+
+- Hoặc logic được viết hoàn toàn từ đầu cho mỗi module *(với khả năng lặp lại trong codebase hiện có)*
+- Hoặc có xu hướng chuyển tất-tất cả các module đã triển khai vào thư mục `shared`, từ đó tạo ra một kho chứa lớn các module *từ nó (trong đó hầu hết chỉ được sử dụng ở một nơi)*
+
+**Ví dụ:**
+
+- *"Tôi có **N** cách triển khai cùng một logic kinh doanh trong dự án của mình, mà tôi vẫn phải trả giá"*
+- *"Có 6 component khác nhau của button/pop-up/... trong dự án"*
+- *"Kho chứa các helper"*
+
+## Yêu cầu
+
+Do đó, có vẻ hợp lý khi trình bày các *yêu cầu mong muốn cho một kiến trúc lý tưởng:*
+
+:::note
+
+Bất cứ đâu nói "dễ dàng", điều đó có nghĩa là "tương đối dễ dàng cho một nhóm rộng các developer", vì rõ ràng là [sẽ không thể tạo ra một giải pháp lý tưởng cho tất cả mọi người](/docs/about/mission#limitations)
+
+:::
+
+### Tính rõ ràng
+
+- Nên **dễ dàng nắm vững và giải thích** dự án và kiến trúc của nó cho team
+- Cấu trúc nên phản ánh **giá trị kinh doanh thực tế của dự án**
+- Phải có **tác dụng phụ và kết nối** rõ ràng giữa các abstraction
+- Nên **dễ phát hiện logic trùng lặp** mà không can thiệp vào các triển khai độc đáo
+- Không nên có **sự phân tán logic** khắp dự án
+- Không nên có **quá nhiều abstraction và quy tắc khác biệt** cho một kiến trúc tốt
+
+### Kiểm soát
+
+- Một kiến trúc tốt nên **tăng tốc giải quyết các tác vụ, việc đưa vào các tính năng**
+- Nên có thể kiểm soát quá trình phát triển dự án
+- Nên dễ dàng **mở rộng, sửa đổi, xóa code**
+- Phải tuân thủ việc **phân tách và cô lập** chức năng
+- Mỗi component của hệ thống phải **dễ dàng thay thế và loại bỏ**
+  - *[Không cần tối ưu hóa cho thay đổi][ext-kof-not-modification] - chúng ta không thể dự đoán tương lai*
+  - *[Tốt hơn là tối ưu hóa cho việc xóa][ext-kof-but-removing] - dựa trên bối cảnh đã tồn tại*
+
+### Khả năng thích ứng
+
+- Một kiến trúc tốt nên có thể áp dụng **cho hầu hết các dự án**
+  - *Với các giải pháp hạ tầng hiện có*
+  - *ở bất kỳ giai đoạn phát triển nào*
+- Không nên phụ thuộc vào framework và nền tảng
+- Nên có thể **dễ dàng mở rộng dự án và team**, với khả năng song song hóa phát triển
+- Nên dễ dàng **thích ứng với các yêu cầu và hoàn cảnh thay đổi**
+
+## Xem thêm
+
+- [(React Berlin Talk) Oleg Isonen - Feature Driven Architecture][ext-kof]
+- [(React SPB Meetup #1) Sergey Sova - Feature Slice][ext-slices-spb]
+- [(Bài viết) Về việc modular hóa dự án][ext-medium]
+- [(Bài viết) Về Separation of Concern và cấu trúc theo feature][ext-ryanlanciaux]
+
+[ext-kof-not-modification]: https://youtu.be/BWAeYuWFHhs?t=1631
+[ext-kof-but-removing]: https://youtu.be/BWAeYuWFHhs?t=1666
+
+[ext-slices-spb]: https://t.me/feature_slices
+[ext-kof]: https://youtu.be/BWAeYuWFHhs
+[ext-medium]: https://alexmngn.medium.com/why-react-developers-should-modularize-their-applications-d26d381854c1
+[ext-ryanlanciaux]: https://ryanlanciaux.com/blog/2017/08/20/a-feature-based-approach-to-react-development/

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/knowledge-types.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/knowledge-types.md
@@ -1,0 +1,29 @@
+---
+sidebar_position: 3
+sidebar_label: Knowledge types
+---
+
+# Các loại kiến thức trong dự án
+
+Có thể phân biệt các "loại kiến thức" sau trong bất kỳ dự án nào:
+
+* **Kiến thức cơ bản**  
+  Kiến thức không thay đổi nhiều theo thời gian, chẳng hạn như thuật toán, khoa học máy tính, cơ chế ngôn ngữ lập trình và API của nó.
+
+* **Technology stack**  
+  Kiến thức về tập hợp các giải pháp kỹ thuật được sử dụng trong dự án, bao gồm ngôn ngữ lập trình, framework và thư viện.
+
+* **Kiến thức dự án**  
+  Kiến thức dành riêng cho dự án hiện tại và không có giá trị bên ngoài nó. Kiến thức này là cần thiết để các developer mới onboard có thể đóng góp hiệu quả.
+
+:::note
+
+**Feature-Sliced Design** được thiết kế để giảm sự phụ thuộc vào "kiến thức dự án", chịu trách nhiệm nhiều hơn và giúp onboard các thành viên team mới dễ dàng hơn.
+
+:::
+
+## Xem thêm {#see-also}
+
+- [(Video 🇷🇺) Ilya Klimov - Về các loại kiến thức][ext-klimov]
+
+[ext-klimov]: https://youtu.be/4xyb_tA-uw0?t=249

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/naming.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/naming.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 4
+---
+
+# Đặt tên
+
+Các developer khác nhau có kinh nghiệm và ngữ cảnh khác nhau, có thể dẫn đến hiểu lầm trong team khi cùng một entity được gọi khác nhau. Ví dụ:
+
+- Component để hiển thị có thể được gọi là "ui", "component", "ui-kit", "view", …
+- Code được tái sử dụng trong toàn bộ ứng dụng có thể được gọi là "core", "shared", "app", …
+- Code logic kinh doanh có thể được gọi là "store", "model", "state", …
+
+## Đặt tên trong Feature-Sliced Design {#naming-in-fsd}
+
+Methodology sử dụng các thuật ngữ cụ thể như:
+
+- "app", "process", "page", "feature", "entity", "shared" như tên layer,
+- "ui", "model", "lib", "api", "config" như tên segment.
+
+Rất quan trọng là phải tuân thủ những thuật ngữ này để tránh nhầm lẫn giữa các thành viên trong team và developer mới tham gia dự án. Việc sử dụng tên chuẩn cũng giúp khi xin trợ giúp từ cộng đồng.
+
+## Xung đột đặt tên {#when-can-naming-interfere}
+
+Xung đột đặt tên có thể xảy ra khi các thuật ngữ được sử dụng trong methodology FSD trùng lặp với các thuật ngữ được sử dụng trong kinh doanh:
+
+- `FSD#process` vs quy trình mô phỏng trong ứng dụng,
+- `FSD#page` vs trang log,
+- `FSD#model` vs model xe hơi.
+
+Ví dụ, một developer nhìn thấy từ "process" trong code sẽ tốn thêm thời gian để tìm hiểu quy trình nào đang được đề cập. Những **xung đột như vậy có thể làm gián đoạn quá trình phát triển**.
+
+Khi từ vựng của dự án chứa thuật ngữ đặc thù của FSD, điều quan trọng là phải cẩn thận khi thảo luận các thuật ngữ này với team và các bên liên quan không quan tâm đến kỹ thuật.
+
+Để giao tiếp hiệu quả với team, được khuyến nghị sử dụng từ viết tắt "FSD" làm tiền tố cho các thuật ngữ methodology. Ví dụ, khi nói về một process, bạn có thể nói, "Chúng ta có thể đặt process này trên layer feature của FSD."
+
+Ngược lại, khi giao tiếp với các bên liên quan không thuộc kỹ thuật, tốt hơn là hạn chế sử dụng thuật ngữ FSD và tránh đề cập đến cấu trúc bên trong của codebase.
+
+## Xem thêm {#see-also}
+
+- [(Thảo luận) Khả năng thích ứng của việc đặt tên][disc-src]
+- [(Thảo luận) Khảo sát đặt tên Entity][disc-naming]
+- [(Thảo luận) "process" vs "flow" vs ...][disc-processes]
+- [(Thảo luận) "model" vs "store" vs ...][disc-model]
+
+[disc-model]: https://github.com/feature-sliced/documentation/discussions/68
+[disc-naming]: https://github.com/feature-sliced/documentation/discussions/31#discussioncomment-464894
+[disc-processes]: https://github.com/feature-sliced/documentation/discussions/20
+[disc-src]: https://github.com/feature-sliced/documentation/discussions/16

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/needs-driven.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/needs-driven.md
@@ -1,0 +1,162 @@
+---
+sidebar_position: 2
+---
+
+# Hướng nhu cầu
+
+:::note Tóm tắt
+
+— _Không thể đưa ra mục tiêu mà tính năng mới sẽ giải quyết? Hoặc có thể vấn đề là bản thân task không được đưa ra? **Điềm mấu chốt cũng là methodology giúp rút ra định nghĩa có vấn đề của các task và mục tiêu**_
+
+— _dự án không sống trong tĩnh - yêu cầu và chức năng liên tục thay đổi. Theo thời gian, code biến thành nhệu, bởi vì lúc bắt đầu dự án chỉ được thiết kế cho ấn tượng ban đầu của mong muốn. **Và nhiệm vụ của một kiến trúc tốt cũng là được mài giũa cho các điều kiện phát triển thay đổi.**_
+
+:::
+
+<!--TODO: Make each section later more independent by itself -->
+<!--TODO: Add more information on the changing requirements of the project -->
+
+## Tại sao?
+
+Để chọn một tên rõ ràng cho một entity và hiểu các thành phần của nó, **bạn cần hiểu rõ task nào sẽ được giải quyết bằng tất cả code này.**
+
+> _@sergeysova: Trong quá trình phát triển, chúng tôi cố gắng đặt cho mỗi entity hoặc function một tên rõ ràng phản ánh ý định và ý nghĩa của code đang được thực thi._
+
+_Sau cùng, không hiểu task thì không thể viết được test đúng bao phủ những trường hợp quan trọng nhất, đặt các lỗi giúp đỡ người dùng ở đúng chỗ, thậm chí là thiếu không làm gián đoạn luồng của người dùng vì các lỗi không quan trọng có thể sửa được._
+
+## Chúng ta đang nói về task gì?
+
+Frontend phát triển ứng dụng và giao diện cho người dùng cuối, nên chúng ta giải quyết các task của những người tiêu dùng này.
+
+Khi một người đến với chúng ta, **anh ta muốn giải quyết một số đau khổ của mình hoặc đóng một nhu cầu.**
+
+_Nhiệm vụ của các manager và analyst là đưa ra nhu cầu này, và triển khai developer tính đến các tính năng của phát triển web (mất kết nối, lỗi backend, typo, nhấm con trỏ hoặc ngón tay)._
+
+**Chính mục tiêu này, mà người dùng đến, là task của các developer.**
+
+> _Một vấn đề nhỏ được giải quyết là một feature trong methodology Feature-Sliced Design — bạn cần cắt toàn bộ phạm vi task của dự án thành các mục tiêu nhỏ._
+
+## Điều này ảnh hưởng đến phát triển như thế nào?
+
+### Phân tách task
+
+Khi một developer bắt đầu triển khai một task, để đơn giản hóa việc hiểu và hỗ trợ code, anh ta trong đầu **cắt nó thành các giai đoạn**:
+
+* đầu tiên _chia thành các entity cấp cao nhất_ và _triển khai chúng_,
+* sau đó những entity này _chia thành những cái nhỏ hơn_
+* và cứ tiếp tục như vậy
+
+_Trong quá trình chia thành các entity, developer bị buộc phải đặt tên cho chúng một cách rõ ràng phản ánh ý tưởng của mình và giúp hiểu task nào code giải quyết khi đọc listing_
+_Đồng thời, chúng ta không quên rằng chúng ta đang cố gắng giúp người dùng giảm bớt đau khổ hoặc thực hiện nhu cầu_
+
+### Hiểu bản chất của task
+
+Nhưng để đặt tên rõ ràng cho một entity, **developer phải biết đủ về mục đích của nó**
+
+* anh ta sẽ sử dụng entity này như thế nào,
+* nó triển khai phần nào của task của người dùng, entity này còn có thể được áp dụng ở đâu khác,
+* nó có thể tham gia vào những task nào khác,
+* và vân vân
+
+Không khó để rút ra kết luận: **trong khi developer sẽ suy ngẫm về tên của các entity trong khuôn khổ của methodology, anh ta sẽ có thể tìm ra các task được đưa ra kém thậm chí trước khi viết code.**
+
+> Làm thế nào đặt tên cho một entity nếu bạn không hiểu rõ những task nào nó có thể giải quyết, làm thế nào bạn có thể chia một task thành các entity nếu bạn không hiểu rõ nó?
+
+## Làm thế nào để đưa ra nó?
+
+**Để đưa ra một task được giải quyết bằng các feature, bạn cần hiểu bản thân task đó**, và đây đã là trách nhiệm của project manager và các analyst.
+
+_Methodology chỉ có thể nói cho developer những task nào mà product manager nên chú ý kỹ._
+
+> _@sergeysova: Toàn bộ frontend chủ yếu là hiển thị thông tin, bất kỳ component nào ở lượt đầu tiên, hiển thị, và sau đó task "hiển thị cho người dùng một cái gì đó" không có giá trị thực tế._
+>
+> _Ngay cả khi không tính đến đặc thù của frontend có thể hỏi, "tại sao tôi phải hiển thị cho bạn", và có thể tiếp tục hỏi cho đến khi không thoát được khỏi đau khổ hoặc nhu cầu của người tiêu dùng._
+
+Người khi chúng ta có thể đến được những nhu cầu hoặc đau khổ cơ bản, chúng ta có thể quay lại và tìm hiểu **chính xác sản phẩm hoặc dịch vụ của bạn có thể giúp người dùng với mục tiêu của họ như thế nào**
+
+Bất kỳ task mới nào trong tracker của bạn đều hướng đến giải quyết các vấn đề kinh doanh, và doanh nghiệp cố gắng giải quyết các task của người dùng đồng thời kiếm tiền từ nó. Điều này có nghĩa là mỗi task đều có những mục tiêu nhất định, ngay cả khi chúng không được viết rõ trong văn bản mô tả.
+
+_**Developer phải hiểu rõ mục tiêu mà task này hay task khác đang theo đuổi**, nhưng không phải công ty nào cũng có thể đủ khả năng xây dựng quy trình hoàn hảo, mặc dù đây là một cuộc trò chuyện riêng, tuy nhiên, developer có thể "ping" các manager phù hợp để tìm hiểu điều này và thực hiện phần việc của mình một cách hiệu quả._
+
+## Và lợi ích là gì?
+
+Bây giờ hãy nhìn toàn bộ quy trình từ đầu đến cuối.
+
+### 1. Hiểu task của người dùng
+
+Khi developer hiểu nỗi đau của họ và cách doanh nghiệp giải quyết chúng, anh ta có thể đưa ra các giải pháp mà doanh nghiệp không có do đặc thù của phát triển web.
+
+> Nhưng tất nhiên, tất cả điều này chỉ có thể hoạt động nếu developer không thờ ơ với những gì anh ta đang làm và vì mục đích gì, nếu không thì _tại sao lại cần methodology và các cách tiếp cận?_
+
+### 2. Cấu trúc hóa và sắp xếp
+
+Với sự hiểu biết về task đến **một cấu trúc rõ ràng cả trong đầu và trong task cùng với code**
+
+### 3. Hiểu feature và các thành phần của nó
+
+**Một feature là một chức năng hữu ích cho người dùng**
+
+* Khi nhiều features được triển khai trong một feature, đây là **vi phạm ranh giới**
+* Feature có thể không thể chia nhỏ và đang phát triển - **và điều này không tệ**
+* **Tệ** - khi feature không trả lời câu hỏi _"Giá trị kinh doanh cho người dùng là gì?"_
+* Không thể có feature "map-office"
+  * Nhưng `booking-meeting-on-the-map`, `search-for-an-employee`, `change-of-workplace` - **có**
+
+> _@sergeysova: Điểm mấu chốt là feature chỉ chứa code triển khai chính chức năng_, không có chi tiết không cần thiết và giải pháp nội bộ (lý tưởng)*
+>
+> *Mở code feature **và chỉ thấy những gì liên quan đến task** - không hơn*
+
+### 4. Lợi ích
+
+Doanh nghiệp rất hiếm khi xoay chuyển hướng đi hoàn toàn sang hướng khác, có nghĩa là **phản ánh các task kinh doanh trong code ứng dụng frontend là lợi ích rất đáng kể.**
+
+_Sau đó bạn không phải giải thích cho mỗi thành viên mới trong team code này hay code kia làm gì, và nói chung tại sao nó được thêm vào - **mọi thứ sẽ được giải thích thông qua các task kinh doanh đã được phản ánh trong code.**_
+
+> Cái được gọi là ["Ngôn ngữ kinh doanh" trong Domain Driven Development][ext-ubiq-lang]
+
+---
+
+## Quay lại thực tế
+
+Nếu quy trình kinh doanh được hiểu và đặt tên tốt ở giai đoạn thiết kế - _thì không có vấn đề gì đặc biệt khi chuyển sự hiểu biết và logic này vào code._
+
+**Tuy nhiên, trong thực tế**, task và chức năng thường được phát triển "quá" lặp đi lặp lại và (hoặc) không có thời gian để suy nghĩ kỹ về thiết kế.
+
+**Kết quả là, feature có ý nghĩa hôm nay, và nếu bạn mở rộng feature này trong một tháng, bạn có thể phải viết lại nửa dự án.**
+
+> *[[Từ cuộc thảo luận][disc-src]]: Developer cố gắng suy nghĩ trước 2-3 bước, tính đến những mong muốn trong tương lai, nhưng ở đây anh ta dựa vào kinh nghiệm của riêng mình*
+>
+> _Kỹ sư có kinh nghiệm thường ngay lập tức nhìn trước 10 bước, và hiểu nơi nào để chia một feature và kết hợp với feature khác_
+>
+> _Nhưng đôi khi có những task mà chưa từng gặp trong kinh nghiệm, và không biết lấy đâu ra sự hiểu biết về cách phân tách hợp lý, với hậu quả không mong muốn ít nhất trong tương lai_
+
+## Vai trò của methodology
+
+**Methodology giúp giải quyết vấn đề của developers, để dễ dàng hơn giải quyết vấn đề của người dùng.**
+
+Không có giải pháp cho vấn đề của developers chỉ vì lợi ích của developers
+
+Nhưng để developer giải quyết task của mình, **bạn cần hiểu task của người dùng** - ngược lại sẽ không hoạt động
+
+### Yêu cầu của methodology
+
+Rõ ràng là bạn cần xác định ít nhất hai yêu cầu cho **Feature-Sliced Design**:
+
+1. Methodology nên chỉ ra **cách tạo features, processes và entities**
+
+    * Có nghĩa là nó nên giải thích rõ ràng _cách chia code giữa chúng_, có nghĩa là việc đặt tên các entities này cũng nên được quy định trong specification.
+
+2. Methodology nên giúp kiến trúc **[dễ dàng thích ứng với yêu cầu thay đổi của dự án][refs-arch--adaptability]**
+
+## Xem thêm
+
+* [(Bài viết) Kích thích cho việc xây dựng task rõ ràng (+ thảo luận)][disc-src]
+    > _**Bài viết hiện tại** là bản chuyển thể của cuộc thảo luận này, bạn có thể đọc phiên bản đầy đủ không cắt tại liên kết_
+* [(Thảo luận) Cách chia chức năng và nó là gì][tg-src]
+* [(Bài viết) "Cách tổ chức ứng dụng của bạn tốt hơn"][ext-medium]
+
+[refs-arch--adaptability]: architecture#adaptability
+
+[ext-medium]: https://alexmngn.medium.com/how-to-better-organize-your-react-applications-2fd3ea1920f1
+[disc-src]: https://t.me/sergeysova/318
+[tg-src]: https://t.me/atomicdesign/18972
+[ext-ubiq-lang]: https://thedomaindrivendesign.io/developing-the-ubiquitous-language

--- a/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/signals.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/about/understanding/signals.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_position: 5
+sidebar_class_name: sidebar-item--wip
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Signal của kiến trúc
+
+<WIP ticket="194" />
+
+> Nếu có giới hạn về phía kiến trúc, thì có những lý do rõ ràng cho điều này, và hậu quả nếu chúng bị bỏ qua
+
+> Methodology và kiến trúc đưa ra signal, và cách xử lý nó phụ thuộc vào những rủi ro bạn sẵn sàng đảm nhận và điều gì phù hợp nhất cho team của bạn)
+
+## Xem thêm
+
+- [(Thread) Về signal từ kiến trúc và dataflow](https://t.me/feature_sliced/2070)
+- [(Thread) Về tính chất cơ bản của kiến trúc](https://t.me/feature_sliced/2492)
+- [(Thread) Về việc làm nổi bật các điểm yếu](https://t.me/feature_sliced/3979)
+- [(Thread) Làm thế nào để hiểu rằng data model bị phình to](https://t.me/feature_sliced/4228)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/branding.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/branding.md
@@ -1,0 +1,82 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+# Hướng dẫn Thương hiệu
+
+Bản sắc thị giác của FSD dựa trên các khái niệm cốt lõi: `Layered`, `Sliced self-contained parts`, `Parts & Compose`, `Segmented`.
+Nhưng chúng tôi cũng có xu hướng thiết kế bản sắc đơn giản, đẹp mắt, thể hiện triết lý FSD và dễ nhận biết.
+
+**Vui lòng sử dụng bản sắc của FSD "nguyên trạng", không thay đổi nhưng với các tài sản của chúng tôi để thuận tiện cho bạn.** Hướng dẫn thương hiệu này sẽ giúp bạn sử dụng bản sắc FSD một cách chính xác.
+
+:::caution Tương thích
+
+FSD trước đây đã có [một bản sắc cũ khác](https://drive.google.com/drive/folders/11Y-3qZ_C9jOFoW2UbSp11YasOhw4yBdl?usp=sharing). Thiết kế cũ không thể hiện được các khái niệm cốt lõi của phương pháp luận. Ngoài ra nó chỉ được tạo như một bản nháp thuần túy, và đáng lẽ phải được hiện thực hóa.
+
+Để sử dụng thương hiệu tương thích và lâu dài, chúng tôi đã cẩn thận thực hiện tái thương hiệu trong một năm (2021-2022). **Vì vậy bạn có thể yên tâm khi sử dụng bản sắc của FSD 🍰**
+
+*Nhưng hãy ưu tiên bản sắc hiện tại, không phải cũ!*
+
+:::
+
+## Tiêu đề
+
+- ✅ **Đúng:** `Feature-Sliced Design`, `FSD`
+- ❌ **Sai:** `Feature-Sliced`, `Feature Sliced`, `FeatureSliced`, `feature-sliced`, `feature sliced`, `FS`
+
+## Emoji
+
+Hình ảnh bánh 🍰 thể hiện khá tốt các khái niệm cốt lõi của FSD, nên nó đã được chọn làm emoji đặc trưng của chúng tôi
+
+> Ví dụ: *"🍰 Phương pháp luận thiết kế kiến trúc cho các dự án Frontend"*
+
+## Logo & Bảng màu
+
+FSD có một vài biến thể logo cho các ngữ cảnh khác nhau, nhưng được khuyến nghị ưu tiên **primary**
+
+<!-- FIXME: refactor; use as Brand component for? -->
+<!-- FIXME: Fix downloading -->
+
+<table style={{ textAlign: "center" }}>
+    <tr>
+        <td>Theme</td>
+        <td>Logo <sub style={{ color: "gray", display: "block" }}>(Ctrl/Cmd + Click để tải xuống)</sub></td>
+        <td>Sử dụng</td>
+    </tr>
+    <tr>
+        <td style={{ color: "#FFF", background: "linear-gradient(135deg, rgba(41,190,220,1) 0%, rgba(81,122,237,1) 100%)" }}>primary <br/> (#29BEDC, #517AED)</td>
+        <td><a href={useBaseUrl("/img/brand/logo-primary.png")} download><img src={useBaseUrl("/img/brand/logo-primary.png")} height="130" alt="logo-primary" /></a></td>
+        <td>Ưu tiên trong hầu hết trường hợp</td>
+    </tr>
+    <tr>
+        <td style={{ color: "#FFF", background: "#3193FF" }}>flat <br/> (#3193FF)</td>
+        <td><a href={useBaseUrl("/img/brand/logo-flat.png")} download><img src={useBaseUrl("/img/brand/logo-flat.png")} height="130" alt="logo-flat" /></a></td>
+        <td>Cho ngữ cảnh một màu</td>
+    </tr>
+    <tr>
+        <td style={{ color: "#000", background: "#FFF" }}>monochrome <br /> (#FFF)</td>
+        <td style={{ color: "#000", background: "#242526" }}><a href={useBaseUrl("/img/brand/logo-monochrome.png")} download><img src={useBaseUrl("/img/brand/logo-monochrome.png")} height="130" alt="logo-monocrhome" /></a></td>
+        <td>Cho ngữ cảnh thang màu xám</td>
+    </tr>
+    <tr>
+        <td style={{ color: "#FFF", background: "#3193FF" }}>square <br/> (#3193FF)</td>
+        <td><a href={useBaseUrl("/img/brand/logo-square.png")} download><img src={useBaseUrl("/img/brand/logo-square.png")} height="130" alt="logo-square" /></a></td>
+        <td>Cho biên hình vuông</td>
+    </tr>
+</table>
+
+## Banner & Sơ đồ
+
+<a href={useBaseUrl("/img/brand/banner-primary.jpg")} download><img src={useBaseUrl("/img/brand/banner-primary.jpg")} height="256" alt="banner-primary" /></a>
+<a href={useBaseUrl("/img/brand/banner-monochrome.jpg")} download><img src={useBaseUrl("/img/brand/banner-monochrome.jpg")} height="256" alt="banner-monochrome" /></a>
+
+## Social Preview
+
+Đang trong quá trình hoàn thiện...
+
+## Template thuyết trình
+
+Đang trong quá trình hoàn thiện...
+
+## Xem thêm
+
+- [Discussion (github)](https://github.com/feature-sliced/documentation/discussions/399)
+- [Lịch sử phát triển với tham khảo (figma)](https://www.figma.com/file/RPphccpoeasVB0lMpZwPVR/FSD-Brand?node-id=0%3A1)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/get-started/cheatsheet.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/get-started/cheatsheet.mdx
@@ -1,0 +1,34 @@
+---
+# sidebar_position: 3
+unlisted: true
+---
+
+# Decomposition cheatsheet
+
+Sử dụng làm tài liệu tham khảo nhanh khi bạn quyết định cách decompose UI của mình. Phiên bản PDF cũng có sẵn bên dưới, để bạn có thể in ra và giữ một bản dưới gối.
+
+## Chọn layer
+
+[Download PDF](/files/choosing-a-layer-en.pdf)
+
+![Definitions of all layers and self-check questions](/img/choosing-a-layer-en.jpg)
+
+## Ví dụ
+
+### Tweet
+
+![decomposed-tweet-bordered-bgLight](/img/decompose-twitter.png)
+
+### GitHub
+
+![decomposed-github-bordered](/img/decompose-github.jpg)
+
+## Xem thêm
+- [(Thread) Logic tổng quát cho feature và entity](https://t.me/feature_sliced/4262)
+- [(Thread) Decomposition của logic phình to](https://t.me/feature_sliced/4210)
+- [(Thread) Về việc hiểu các vùng trách nhiệm trong decomposition](https://t.me/feature_sliced/4088)
+- [(Thread) Decomposition của Product List widget](https://t.me/feature_sliced/3828)
+- [(Article) Các cách tiếp cận khác nhau cho decomposition của logic](https://www.pluralsight.com/guides/how-to-organize-your-react-+-redux-codebase)
+- [(Thread) Về sự khác biệt giữa feature và entity](https://t.me/feature_sliced/3776)
+- [(Thread) Về sự khác biệt giữa things và entity (2)](https://t.me/feature_sliced/3248)
+- [(Thread) Về việc áp dụng tiêu chí cho decomposition](https://t.me/feature_sliced/3833)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/get-started/faq.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/get-started/faq.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 20
+pagination_next: guides/examples/auth
+---
+
+# FAQ
+
+:::info
+
+Bạn có thể đặt câu hỏi trong [Telegram chat][telegram], [Discord community][discord], và [GitHub Discussions][github-discussions] của chúng tôi.
+
+:::
+
+### Có toolkit hay linter nào không?
+
+Có! Chúng tôi có linter tên là [Steiger][ext-steiger] để kiểm tra kiến trúc project của bạn và có [folder generator][ext-tools] thông qua CLI hoặc IDE.
+
+### Đặt layout/template của trang ở đâu?
+
+Nếu bạn cần layout markup thuần túy, bạn có thể giữ chúng trong `shared/ui`. Nếu bạn cần sử dụng các layer cao hơn bên trong, có một vài lựa chọn:
+
+- Có lẽ bạn không cần layout chút nào? Nếu layout chỉ có vài dòng, có thể hợp lý hơn là duplicate code trong mỗi trang thay vì cố gắng trừu tượng hóa nó.
+- Nếu bạn thực sự cần layout, bạn có thể có chúng như các widget hoặc trang riêng biệt, và compose chúng trong cấu hình router ở App. Nested routing là một lựa chọn khác.
+
+### Sự khác biệt giữa feature và entity là gì?
+
+_Entity_ là khái niệm thực tế mà app của bạn đang làm việc với. _Feature_ là tương tác cung cấp giá trị thực tế cho người dùng app của bạn, điều mà mọi người muốn làm với các entity của bạn.
+
+Để biết thêm thông tin cùng với ví dụ, xem trang Reference về [slice][reference-entities].
+
+### Tôi có thể embed page/feature/entity vào nhau không?
+
+Có, nhưng việc embedding này nên xảy ra ở các layer cao hơn. Ví dụ, bên trong widget, bạn có thể import cả feature rồi insert feature này vào feature khác như props/children.
+
+Bạn không thể import feature này từ feature khác, điều này bị cấm bởi [**import rule on layers**][import-rule-layers].
+
+### Còn Atomic Design thì sao?
+
+Phiên bản hiện tại của phương pháp luận không yêu cầu cũng không cấm việc sử dụng Atomic Design cùng với Feature-Sliced Design.
+
+Ví dụ, Atomic Design [có thể được áp dụng tốt](https://t.me/feature_sliced/1653) cho segment `ui` của các module.
+
+### Có tài nguyên/bài viết/v.v. hữu ích nào về FSD không?
+
+Có! https://github.com/feature-sliced/awesome
+
+### Tại sao tôi cần Feature-Sliced Design?
+
+Nó giúp bạn và team của bạn nhanh chóng tổng quan project theo các component mang lại giá trị chính. Kiến trúc được tiêu chuẩn hóa giúp tăng tốc onboarding và giải quyết các tranh luận về cấu trúc code. Xem trang [motivation][motivation] để tìm hiểu thêm về lý do FSD được tạo ra.
+
+### Developer mới có cần architecture/methodology không?
+
+Có thì tốt hơn là không
+
+*Thường thì khi bạn thiết kế và phát triển project một mình, mọi thứ diễn ra suôn sẻ. Nhưng nếu có tạm dừng trong quá trình phát triển, có thêm developer mới vào team - thì vấn đề sẽ xuất hiện*
+
+### Làm thế nào để làm việc với authorization context?
+
+Trả lời [ở đây](/docs/guides/examples/auth)
+
+[ext-steiger]: https://github.com/feature-sliced/steiger
+[ext-tools]: https://github.com/feature-sliced/awesome?tab=readme-ov-file#tools
+[import-rule-layers]: /docs/reference/layers#import-rule-on-layers
+[reference-entities]: /docs/reference/layers#entities
+[motivation]: /docs/about/motivation
+[telegram]: https://t.me/feature_sliced
+[discord]: https://discord.gg/S8MzWTUsmp
+[github-discussions]: https://github.com/feature-sliced/documentation/discussions

--- a/i18n/vi/docusaurus-plugin-content-docs/current/get-started/overview.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/get-started/overview.mdx
@@ -1,0 +1,143 @@
+---
+sidebar_position: 1
+---
+
+# Tổng quan
+
+**Feature-Sliced Design** (FSD) là một phương pháp thiết kế kiến trúc để xây dựng các ứng dụng frontend. Nói đơn giản, đây là tập hợp các quy tắc và quy ước để tổ chức code. Mục đích chính của phương pháp này là làm cho dự án trở nên dễ hiểu và ổn định hơn khi đối mặt với những yêu cầu kinh doanh liên tục thay đổi.
+
+Ngoài tập hợp các quy ước, FSD còn là một bộ công cụ. Chúng tôi có [linter][ext-steiger] để kiểm tra kiến trúc dự án của bạn, [trình tạo thư mục][ext-tools] thông qua CLI hoặc IDE, cũng như thư viện phong phú các [ví dụ][examples].
+
+## Có phù hợp với tôi không? {#is-it-right-for-me}
+
+FSD có thể được triển khai trong các dự án và nhóm với bất kỳ quy mô nào. Nó phù hợp với dự án của bạn nếu:
+
+- Bạn đang làm **frontend** (UI trên web, mobile, desktop, v.v.)
+- Bạn đang xây dựng một **ứng dụng**, không phải thư viện
+
+Vâng, chỉ đơn giản thế thôi! Không có ràng buộc nào về ngôn ngữ lập trình, UI framework, hoặc state manager bạn sử dụng. Bạn cũng có thể áp dụng FSD từng bước một, sử dụng nó trong monorepo, và mở rộng quy mô lớn bằng cách chia ứng dụng thành các package và triển khai FSD riêng lẻ trong từng package.
+
+Nếu bạn đã có một kiến trúc và đang cân nhắc chuyển sang FSD, hãy đảm bảo rằng kiến trúc hiện tại đang **gây ra vấn đề** trong nhóm của bạn. Ví dụ, nếu dự án của bạn đã trở nên quá lớn và liên kết chặt chẽ với nhau khiến việc triển khai tính năng mới trở nên kém hiệu quả, hoặc nếu bạn dự kiến có nhiều thành viên mới tham gia nhóm. Nếu kiến trúc hiện tại hoạt động tốt, có lẽ không đáng để thay đổi. Nhưng nếu bạn quyết định migrate, hãy xem phần [Migration][migration] để được hướng dẫn.
+
+## Ví dụ cơ bản {#basic-example}
+
+Đây là một dự án đơn giản triển khai FSD:
+
+- `📁 app`
+- `📁 pages`
+- `📁 shared`
+
+Những thư mục cấp cao này được gọi là _layer_. Hãy xem sâu hơn:
+
+- `📂 app`
+   - `📁 routes`
+   - `📁 analytics`
+- `📂 pages`
+   - `📁 home`
+   - `📂 article-reader`
+      - `📁 ui`
+      - `📁 api`
+   - `📁 settings`
+- `📂 shared`
+   - `📁 ui`
+   - `📁 api`
+
+Các thư mục bên trong `📂 pages` được gọi là _slice_. Chúng chia layer theo domain (trong trường hợp này, theo trang).
+
+Các thư mục bên trong `📂 app`, `📂 shared`, và `📂 pages/article-reader` được gọi là _segment_, và chúng chia các slice (hoặc layer) theo mục đích kỹ thuật, tức là code đó dùng để làm gì.
+
+## Các khái niệm {#concepts}
+
+Layer, slice, và segment tạo thành một hệ thống phân cấp như sau:
+
+<figure>
+   ![Hierarchy of FSD concepts, described below](/img/visual_schema.jpg)
+
+   <figcaption style={{ fontStyle: "italic", fontSize: "0.9em" }}>
+      <p>Hình minh họa: ba cột, được gắn nhãn từ trái sang phải lần lượt là "Layers", "Slices", và "Segments".</p>
+      <p>Cột "Layers" chứa bảy phân chia được sắp xếp từ trên xuống dưới và được gắn nhãn "app", "processes", "pages", "widgets", "features", "entities", và "shared". Phân chia "processes" bị gạch ngang. Phân chia "entities" được kết nối với cột thứ hai "Slices" theo cách truyền đạt rằng cột thứ hai là nội dung của "entities".</p>
+      <p>Cột "Slices" chứa ba phân chia được sắp xếp từ trên xuống dưới và được gắn nhãn "user", "post", và "comment". Phân chia "post" được kết nối với cột thứ ba "Segments" theo cùng cách như vậy để nó là nội dung của "post".</p>
+      <p>Cột "Segments" chứa ba phân chia, được sắp xếp từ trên xuống dưới và được gắn nhãn "ui", "model", và "api".</p>
+   </figcaption>
+</figure>
+
+### Layer {#layers}
+
+Các layer được tiêu chuẩn hóa trên tất cả các dự án FSD. Bạn không cần phải sử dụng tất cả các layer, nhưng tên của chúng rất quan trọng. Hiện tại có bảy layer (từ trên xuống dưới):
+
+1. **App** — mọi thứ khiến ứng dụng chạy được — routing, entrypoint, global style, provider.
+2. **Processes** (deprecated) — các kịch bản phức tạp liên quan đến nhiều trang.
+3. **Pages** — các trang đầy đủ hoặc các phần lớn của trang trong nested routing.
+4. **Widget** — các khối chức năng hoặc UI lớn, tự chứa, thường cung cấp toàn bộ một use case.
+5. **Feature** — các triển khai _tái sử dụng_ của toàn bộ tính năng sản phẩm, tức là các hành động mang lại giá trị kinh doanh cho người dùng.
+6. **Entity** — các thực thể kinh doanh mà dự án làm việc với, như `user` hoặc `product`.
+7. **Shared** — chức năng tái sử dụng, đặc biệt khi nó tách rời khỏi đặc điểm cụ thể của dự án/kinh doanh, mặc dù không nhất thiết.
+
+:::warning
+
+Các layer **App** và **Shared**, không giống như các layer khác, không có slice và được chia trực tiếp thành các segment.
+
+Tuy nhiên, tất cả các layer khác — **Entity**, **Feature**, **Widget**, và **Page**, giữ nguyên cấu trúc trong đó bạn phải tạo slice trước, bên trong đó bạn tạo các segment.
+
+:::
+Điều thú vị với các layer là các module ở một layer chỉ có thể biết về và import từ các module từ các layer ở phía dưới một cách nghiêm ngặt.
+
+### Slice {#slices}
+
+Tiếp theo là các slice, chúng phân chia code theo domain business. Bạn có thể tự do chọn bất kỳ tên nào cho chúng và tạo nhiều như bạn muốn. Các slice làm cho codebase của bạn dễ điều hướng hơn bằng cách giữ các module có liên quan logic gần nhau.
+
+Các slice không thể sử dụng slice khác trên cùng layer, và điều đó giúp với tính liên kết cao và khớp nối thấp.
+
+### Segment {#segments}
+
+Các slice, cũng như các layer App và Shared, bao gồm các segment, và các segment nhóm code của bản theo mục đích của nó. Tên segment không bị ràng buộc bởi tiêu chuẩn, nhưng có một số tên quy ước cho các mục đích phổ biến nhất:
+
+- `ui` — mọi thứ liên quan đến hiển thị UI: UI component, date formatter, style, v.v.
+- `api` — tương tác backend: request function, data type, mapper, v.v.
+- `model` — model dữ liệu: schema, interface, store, và business logic.
+- `lib` — library code mà các module khác trên slice này cần.
+- `config` — file cấu hình và feature flag.
+
+Thường thì những segment này đủ cho hầu hết các layer, bạn chỉ tạo segment riêng của mình trong Shared hoặc App, nhưng đây không phải là quy tắc bắt buộc.
+
+## Ưu điểm {#advantages}
+
+- **Tính thống nhất**  
+  Vì cấu trúc được tiêu chuẩn hóa, các dự án trở nên thống nhất hơn, điều này làm cho việc onboard thành viên mới dễ dàng hơn cho nhóm.
+
+- **Ổn định trước các thay đổi và refactoring**  
+  Một module trên một layer không thể sử dụng các module khác trên cùng layer, hoặc các layer ở trên.  
+  Điều này cho phép bạn thực hiện các sửa đổi độc lập mà không có hậu quả không lường trước đối với phần còn lại của ứng dụng.
+
+- **Kiểm soát việc tái sử dụng logic**  
+  Tùy thuộc vào layer, bạn có thể làm cho code rất có thể tái sử dụng hoặc rất cục bộ.  
+  Điều này giữ sự cân bằng giữa việc tuân theo nguyên tắc **DRY** và tính thực tế.
+
+- **Định hướng vào nhu cầu kinh doanh và người dùng**  
+  Ứng dụng được chia theo các domain kinh doanh và việc sử dụng ngôn ngữ kinh doanh được khuyến khích trong việc đặt tên, để bạn có thể thực hiện công việc sản phẩm hữu ích mà không cần hiểu đầy đủ tất cả các phần không liên quan khác của dự án.
+
+## Áp dụng từng bước {#incremental-adoption}
+
+Nếu bạn có một codebase hiện có mà bạn muốn migrate sang FSD, chúng tôi đề xuất chiến lược sau. Chúng tôi thấy nó hữu ích trong kinh nghiệm migrate của chính mình.
+
+1. Bắt đầu bằng cách từ từ định hình các layer App và Shared từng module một để tạo nền tảng.
+
+2. Phân phối tất cả UI hiện có trên Widget và Page bằng cách sơ bộ, ngay cả khi chúng có dependency vi phạm các quy tắc của FSD.
+
+3. Bắt đầu từ từ giải quyết các vi phạm import và cũng trích xuất Entity và có thể cả Feature.
+
+Nên tránh thêm các entity lớn mới trong khi refactor hoặc chỉ refactor một số phần nhất định của dự án.
+
+## Bước tiếp theo {#next-steps}
+
+- **Muốn nắm bắt tốt cách tư duy trong FSD?** Xem [Tutorial][tutorial].
+- **Bạn thích học từ ví dụ?** Chúng tôi có rất nhiều trong phần [Examples][examples].
+- **Bạn có câu hỏi?** Ghé thăm [Telegram chat][ext-telegram] của chúng tôi và nhận trợ giúp từ cộng đồng.
+
+[tutorial]: /docs/get-started/tutorial
+[examples]: /examples
+[migration]: /docs/guides/migration/from-custom
+[ext-steiger]: https://github.com/feature-sliced/steiger
+[ext-tools]: https://github.com/feature-sliced/awesome?tab=readme-ov-file#tools
+[ext-telegram]: https://t.me/feature_sliced
+

--- a/i18n/vi/docusaurus-plugin-content-docs/current/get-started/tutorial.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/get-started/tutorial.md
@@ -1,0 +1,2262 @@
+---
+sidebar_position: 2
+---
+# Tutorial
+
+## Phần 1. Trên giấy
+
+Tutorial này sẽ xem xét một app thực tế, còn được biết đến với tên Conduit. Conduit là một bản clone cơ bản của [Medium](https://medium.com/) — nó cho phép bạn đọc và viết bài, cũng như bình luận trên các bài viết của người khác.
+
+![Conduit home page](/img/tutorial/realworld-feed-anonymous.jpg)
+
+Đây là một ứng dụng khá nhỏ, vì vậy chúng ta sẽ giữ nó đơn giản và tránh phân tách quá mức. Rất có thể toàn bộ ứng dụng sẽ chỉ cần ba layer: **App**, **Pages**, và **Shared**. Nếu không, chúng ta sẽ giới thiệu thêm các layer khi cần. Sẵn sàng chưa?
+
+### Bắt đầu bằng việc liệt kê các trang
+
+Nếu nhìn vào ảnh chụp màn hình ở trên, chúng ta có thể giả định ít nhất những trang sau:
+
+- Trang chủ (article feed)
+- Đăng nhập và đăng ký
+- Đọc article
+- Chỉnh sửa article
+- Xem profile người dùng
+- Chỉnh sửa profile người dùng (user settings)
+
+Mỗi trang này sẽ trở thành một *slice* riêng trên *layer* Pages. Hãy nhớ lại từ phần tổng quan rằng slice chỉ đơn giản là các folder bên trong layer, và layer chỉ đơn giản là các folder có tên định sẵn như `pages`.
+
+Như vậy, folder Pages của chúng ta sẽ trông như thế này:
+
+```
+📂 pages/
+  📁 feed/
+  📁 sign-in/
+  📁 article-read/
+  📁 article-edit/
+  📁 profile/
+  📁 settings/
+```
+
+Sự khác biệt chính của Feature-Sliced Design so với cấu trúc code không được quy định là các pages không thể tham chiếu lẫn nhau. Nghĩa là, một page không thể import code từ trang khác. Điều này là do **quy tắc import trên các layer**:
+
+*Một module (file) trong một slice chỉ có thể import các slice khác khi chúng nằm trên các layer ở bên dưới.*
+
+Trong trường hợp này, một trang là một slice, vì vậy các module (file) bên trong trang này chỉ có thể tham chiếu code từ các layer bên dưới, không phải từ cùng layer Pages.
+
+### Nhìn kỹ hơn vào feed
+
+<figure>
+  ![Anonymous user's perspective](/img/tutorial/realworld-feed-anonymous.jpg)
+  <figcaption>
+    _Từ góc nhìn của người dùng ẩn danh_
+  </figcaption>
+</figure>
+
+<figure>
+  ![Authenticated user's perspective](/img/tutorial/realworld-feed-authenticated.jpg)
+  <figcaption>
+    _Từ góc nhìn của người dùng đã xác thực_
+  </figcaption>
+</figure>
+
+Có ba khu vực động trên trang feed:
+
+1. Các link đăng nhập với thông báo nếu bạn đã đăng nhập
+2. Danh sách các tag kích hoạt việc lọc trong feed
+3. Một/hai feed của các article, mỗi article có nút like
+
+Các link đăng nhập là một phần của header chung cho tất cả các trang, chúng ta sẽ xem xét nó riêng.
+
+#### Danh sách các tag
+
+Để xây dựng danh sách các tag, chúng ta cần lấy các tag có sẵn, render mỗi tag dưới dạng chip, và lưu trữ các tag đã chọn trong client-side storage. Những thao tác này thuộc các danh mục "tương tác API", "giao diện người dùng", và "lưu trữ". Trong Feature-Sliced Design, code được phân tách theo mục đích sử dụng *segment*. Segment là các folder trong slice, và chúng có thể có tên tùy ý để mô tả mục đích, nhưng một số mục đích rất phổ biến nên có quy ước cho một số tên segment nhất định:
+
+- 📂 `api/` cho các tương tác backend
+- 📂 `ui/` cho code xử lý rendering và giao diện
+- 📂 `model/` cho storage và business logic
+- 📂 `config/` cho feature flag, biến môi trường và các hình thức cấu hình khác
+
+Chúng ta sẽ đặt code lấy tag vào `api`, component tag vào `ui`, và tương tác storage vào `model`.
+
+#### Các article
+
+Sử dụng cùng nguyên tắc nhóm, chúng ta có thể phân tách feed của các article thành ba segment tương tự:
+
+- 📂 `api/`: lấy các article được phân trang với số lượng like; thích một article
+- 📂 `ui/`:
+    - danh sách tab có thể render thêm tab nếu có tag được chọn
+    - article riêng lẻ
+    - phân trang chức năng
+- 📂 `model/`: client-side storage của các article hiện tại được tải và trang hiện tại (nếu cần)
+
+### Tái sử dụng code chung
+
+Hầu hết các trang có ý định rất khác nhau, nhưng một số thứ nhất định vẫn giữ nguyên trong toàn bộ app — ví dụ, UI kit tuân thủ design language, hoặc quy ước trên backend rằng mọi thứ được thực hiện bằng REST API với cùng phương thức xác thực. Vì các slice được thiết kế để tách biệt, việc tái sử dụng code được hỗ trợ bởi một layer thấp hơn, **Shared**.
+
+Shared khác với các layer khác ở chỗ nó chứa các segment, không phải slice. Theo cách này, layer Shared có thể được coi là sự kết hợp giữa một layer và một slice.
+
+Thông thường, code trong Shared không được lên kế hoạch trước, mà được trích xuất trong quá trình phát triển, vì chỉ trong quá trình phát triển mới rõ phần nào của code thực sự được chia sẻ. Tuy nhiên, vẫn hữu ích khi ghi nhớ loại code nào thuộc về Shared:
+
+- 📂 `ui/` — UI kit, giao diện thuần túy, không có business logic. Ví dụ, button, modal dialog, form input.
+- 📂 `api/` — wrapper tiện lợi xung quanh các primitive tạo request (như `fetch()` trên Web) và, tùy chọn, các function để kích hoạt request cụ thể theo đặc tả backend.
+- 📂 `config/` — phân tích biến môi trường
+- 📂 `i18n/` — cấu hình hỗ trợ ngôn ngữ
+- 📂 `router/` — routing primitive và route constant
+
+Đó chỉ là một vài ví dụ về tên segment trong Shared, nhưng bạn có thể bỏ qua bất kỳ segment nào hoặc tạo segment của riêng bạn. Điều quan trọng duy nhất cần nhớ khi tạo segment mới là tên segment nên mô tả **mục đích (tại sao), không phải bản chất (cái gì)**. Các tên như "components", "hooks", "modals" *không nên* được sử dụng vì chúng mô tả những file này là gì, nhưng không giúp điều hướng code bên trong. Điều này yêu cầu mọi người trong team phải đào sâu vào từng file trong những folder như vậy và cũng giữ code không liên quan gần nhau, dẫn đến việc refactoring ảnh hưởng đến các khu vực rộng lớn của code và do đó làm cho việc review code và testing khó khăn hơn.
+
+### Định nghĩa public API nghiêm ngặt
+
+Trong ngữ cảnh của Feature-Sliced Design, thuật ngữ *public API* đề cập đến một slice hoặc segment khai báo những gì có thể được import từ nó bởi các module khác trong dự án. Ví dụ, trong JavaScript đó có thể là file `index.js` re-export các object từ các file khác trong slice. Điều này cho phép tự do refactoring code bên trong slice miễn là hợp đồng với thế giới bên ngoài (tức là public API) vẫn giữ nguyên.
+
+Đối với layer Shared không có slice, thường thuận tiện hơn khi định nghĩa public API riêng cho mỗi segment thay vì định nghĩa một index duy nhất cho mọi thứ trong Shared. Điều này giữ các import từ Shared được tổ chức tự nhiên theo ý định. Đối với các layer khác có slice, ngược lại — thường thực tế hơn khi định nghĩa một index cho mỗi slice và để slice quyết định tập hợp segment riêng của nó mà thế giới bên ngoài không biết vì các layer khác thường có ít export hơn nhiều.
+
+Các slice/segment của chúng ta sẽ xuất hiện với nhau như sau:
+
+```
+📂 pages/
+  📂 feed/
+    📄 index
+  📂 sign-in/
+    📄 index
+  📂 article-read/
+    📄 index
+  📁 …
+📂 shared/
+  📂 ui/
+    📄 index
+  📂 api/
+    📄 index
+  📁 …
+```
+
+Bất cứ thứ gì bên trong các folder như `pages/feed` hoặc `shared/ui` chỉ được biết đến bởi những folder đó, và các file khác không nên dựa vào cấu trúc nội bộ của những folder này.
+
+### Khối UI lớn được tái sử dụng
+
+Trước đó chúng ta đã ghi chú để xem lại header xuất hiện trên mỗi trang. Xây dựng lại từ đầu trên mỗi trang sẽ không thực tế, vì vậy việc muốn tái sử dụng nó là điều tự nhiên. Chúng ta đã có Shared để hỗ trợ tái sử dụng code, tuy nhiên, có một lưu ý khi đặt các khối UI lớn trong Shared — layer Shared không được biết về bất kỳ layer nào ở trên.
+
+Giữa Shared và Pages có ba layer khác: Entities, Features, và Widgets. Một số dự án có thể có thứ gì đó trong những layer đó mà họ cần trong một khối có thể tái sử dụng lớn, và điều đó có nghĩa là chúng ta không thể đặt khối có thể tái sử dụng đó trong Shared, nếu không nó sẽ import từ các layer trên, điều này bị cấm. Đó là lúc layer Widgets xuất hiện. Nó được đặt phía trên Shared, Entities, và Features, vì vậy nó có thể sử dụng tất cả chúng.
+
+Trong trường hợp của chúng ta, header rất đơn giản — đó là logo tĩnh và điều hướng cấp cao nhất. Điều hướng cần thực hiện request đến API để xác định người dùng hiện tại có đăng nhập hay không, nhưng điều đó có thể được xử lý bằng một import đơn giản từ segment `api`. Do đó, chúng ta sẽ giữ header của mình trong Shared.
+
+### Nhìn kỹ vào trang có form
+
+Hãy cũng kiểm tra một trang được thiết kế để chỉnh sửa, không phải đọc. Ví dụ, trình soạn thảo article:
+
+![Conduit post editor](/img/tutorial/realworld-editor-authenticated.jpg)
+
+Nó trông đơn giản, nhưng chứa một số khía cạnh của phát triển ứng dụng mà chúng ta chưa khám phá — validation form, trạng thái lỗi, và data persistence.
+
+Nếu chúng ta xây dựng trang này, chúng ta sẽ lấy một số input và button từ Shared và ghép thành một form trong segment `ui` của trang này. Sau đó, trong segment `api`, chúng ta sẽ định nghĩa một mutation request để tạo article trên backend.
+
+Để validate request trước khi gửi, chúng ta cần một validation schema, và vị trí tốt cho nó là segment `model`, vì nó là data model. Ở đó chúng ta sẽ tạo ra các thông báo lỗi và hiển thị chúng bằng một component khác trong segment `ui`.
+
+Để cải thiện trải nghiệm người dùng, chúng ta cũng có thể persist các input để ngăn mất dữ liệu vô tình. Đây cũng là công việc của segment `model`.
+
+### Tóm tắt
+
+Chúng ta đã kiểm tra một số trang và phác thảo cấu trúc sơ bộ cho ứng dụng của mình:
+
+1. Layer Shared
+    1. `ui` sẽ chứa UI kit có thể tái sử dụng của chúng ta
+    2. `api` sẽ chứa các tương tác primitive với backend
+    3. Phần còn lại sẽ được sắp xếp theo yêu cầu
+2. Layer Pages — mỗi trang là một slice riêng biệt
+    1. `ui` sẽ chứa chính trang đó và tất cả các phần của nó
+    2. `api` sẽ chứa data fetching chuyên biệt hơn, sử dụng `shared/api`
+    3. `model` có thể chứa client-side storage của dữ liệu mà chúng ta sẽ hiển thị
+
+Hãy bắt đầu xây dựng!
+
+## Phần 2. Trong code
+
+Bây giờ chúng ta đã có kế hoạch, hãy đưa nó vào thực hành. Chúng ta sẽ sử dụng React và [Remix](https://remix.run).
+
+Có một template sẵn sàng cho dự án này, clone nó từ GitHub để có được khởi đầu: [https://github.com/feature-sliced/tutorial-conduit/tree/clean](https://github.com/feature-sliced/tutorial-conduit/tree/clean).
+
+Cài đặt dependencies với `npm install` và khởi động development server với `npm run dev`. Mở [http://localhost:3000](http://localhost:3000) và bạn sẽ thấy một app trống.
+
+### Bố trí các trang
+
+Hãy bắt đầu bằng việc tạo các component trống cho tất cả các trang của chúng ta. Chạy lệnh sau trong dự án của bạn:
+
+```bash
+npx fsd pages feed sign-in article-read article-edit profile settings --segments ui
+```
+
+Điều này sẽ tạo các folder như `pages/feed/ui/` và một file index, `pages/feed/index.ts`, cho mỗi trang.
+
+### Kết nối trang feed
+
+Hãy kết nối route gốc của ứng dụng với trang feed. Tạo một component, `FeedPage.tsx` trong `pages/feed/ui` và đặt nội dung sau vào đó:
+
+
+```tsx title="pages/feed/ui/FeedPage.tsx"
+export function FeedPage() {
+  return (
+    <div className="home-page">
+      <div className="banner">
+        <div className="container">
+          <h1 className="logo-font">conduit</h1>
+          <p>A place to share your knowledge.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+Sau đó re-export component này trong public API của trang feed, file `pages/feed/index.ts`:
+
+
+
+```ts title="pages/feed/index.ts"
+export { FeedPage } from "./ui/FeedPage";
+```
+
+Bây giờ kết nối nó với root route. Trong Remix, routing dựa trên file, và các file route được đặt trong folder `app/routes`, điều này phù hợp với Feature-Sliced Design.
+
+Sử dụng component `FeedPage` trong `app/routes/_index.tsx`:
+
+```tsx title="app/routes/_index.tsx"
+import type { MetaFunction } from "@remix-run/node";
+import { FeedPage } from "pages/feed";
+
+export const meta: MetaFunction = () => {
+  return [{ title: "Conduit" }];
+};
+
+export default FeedPage;
+```
+
+Sau đó, nếu bạn chạy dev server và mở ứng dụng, bạn sẽ thấy banner của Conduit!
+
+![The banner of Conduit](/img/tutorial/conduit-banner.jpg)
+
+### API client
+
+Để giao tiếp với RealWorld backend, hãy tạo một API client tiện lợi trong Shared. Tạo hai segment, `api` cho client và `config` cho các biến như backend base URL:
+
+```bash
+npx fsd shared --segments api config
+```
+
+Sau đó tạo `shared/config/backend.ts`:
+
+```tsx title="shared/config/backend.ts"
+export { mockBackendUrl as backendBaseUrl } from "mocks/handlers";
+```
+
+```tsx title="shared/config/index.ts"
+export { backendBaseUrl } from "./backend";
+```
+
+Vì dự án RealWorld tiện lợi cung cấp [đặc tả OpenAPI](https://github.com/gothinkster/realworld/blob/main/api/openapi.yml), chúng ta có thể tận dụng các type được tự động tạo cho client của mình. Chúng ta sẽ sử dụng [package `openapi-fetch`](https://openapi-ts.pages.dev/openapi-fetch/) đi kèm với type generator bổ sung.
+
+Chạy lệnh sau để tạo API typing cập nhật:
+
+```bash
+npm run generate-api-types
+```
+
+Điều này sẽ tạo file `shared/api/v1.d.ts`. Chúng ta sẽ sử dụng file này để tạo typed API client trong `shared/api/client.ts`:
+
+```tsx title="shared/api/client.ts"
+import createClient from "openapi-fetch";
+
+import { backendBaseUrl } from "shared/config";
+import type { paths } from "./v1";
+
+export const { GET, POST, PUT, DELETE } = createClient<paths>({ baseUrl: backendBaseUrl });
+```
+
+```tsx title="shared/api/index.ts"
+export { GET, POST, PUT, DELETE } from "./client";
+```
+
+### Dữ liệu thực trong feed
+
+Bây giờ chúng ta có thể tiến hành thêm các article vào feed, được lấy từ backend. Hãy bắt đầu bằng cách triển khai component preview article.
+
+Tạo `pages/feed/ui/ArticlePreview.tsx` với nội dung sau:
+
+```tsx title="pages/feed/ui/ArticlePreview.tsx"
+export function ArticlePreview({ article }) { /* TODO */ }
+```
+
+Vì chúng ta viết bằng TypeScript, sẽ tốt nếu có một article object được type. Nếu chúng ta khám phá `v1.d.ts` được tạo, chúng ta có thể thấy rằng article object có sẵn thông qua `components["schemas"]["Article"]`. Vì vậy hãy tạo file với các data model của chúng ta trong Shared và export các model:
+
+```tsx title="shared/api/models.ts"
+import type { components } from "./v1";
+
+export type Article = components["schemas"]["Article"];
+```
+
+```tsx title="shared/api/index.ts"
+export { GET, POST, PUT, DELETE } from "./client";
+
+export type { Article } from "./models";
+```
+
+Bây giờ chúng ta có thể quay lại component preview article và điền markup với dữ liệu. Cập nhật component với nội dung sau:
+
+```tsx title="pages/feed/ui/ArticlePreview.tsx"
+import { Link } from "@remix-run/react";
+import type { Article } from "shared/api";
+
+interface ArticlePreviewProps {
+  article: Article;
+}
+
+export function ArticlePreview({ article }: ArticlePreviewProps) {
+  return (
+    <div className="article-preview">
+      <div className="article-meta">
+        <Link to={`/profile/${article.author.username}`} prefetch="intent">
+          <img src={article.author.image} alt="" />
+        </Link>
+        <div className="info">
+          <Link
+            to={`/profile/${article.author.username}`}
+            className="author"
+            prefetch="intent"
+          >
+            {article.author.username}
+          </Link>
+          <span className="date" suppressHydrationWarning>
+            {new Date(article.createdAt).toLocaleDateString(undefined, {
+              dateStyle: "long",
+            })}
+          </span>
+        </div>
+        <button className="btn btn-outline-primary btn-sm pull-xs-right">
+          <i className="ion-heart"></i> {article.favoritesCount}
+        </button>
+      </div>
+      <Link
+        to={`/article/${article.slug}`}
+        className="preview-link"
+        prefetch="intent"
+      >
+        <h1>{article.title}</h1>
+        <p>{article.description}</p>
+        <span>Read more...</span>
+        <ul className="tag-list">
+          {article.tagList.map((tag) => (
+            <li key={tag} className="tag-default tag-pill tag-outline">
+              {tag}
+            </li>
+          ))}
+        </ul>
+      </Link>
+    </div>
+  );
+}
+```
+
+Button like hiện tại chưa làm gì cả, chúng ta sẽ sửa điều đó khi đến trang đọc article và triển khai tính năng thích.
+
+Bây giờ chúng ta có thể lấy các article và render ra một loạt các card này. Lấy dữ liệu trong Remix được thực hiện bằng *loader* — các function phía server lấy chính xác những gì trang cần. Loader tương tác với API thay mặt cho trang, vì vậy chúng ta sẽ đặt chúng trong segment `api` của trang:
+
+```tsx title="pages/feed/api/loader.ts"
+import { json } from "@remix-run/node";
+
+import { GET } from "shared/api";
+
+export const loader = async () => {
+  const { data: articles, error, response } = await GET("/articles");
+
+  if (error !== undefined) {
+    throw json(error, { status: response.status });
+  }
+
+  return json({ articles });
+};
+```
+
+Để kết nối nó với trang, chúng ta cần export nó với tên `loader` từ route file:
+
+```tsx title="pages/feed/index.ts"
+export { FeedPage } from "./ui/FeedPage";
+export { loader } from "./api/loader";
+```
+
+```tsx title="app/routes/_index.tsx"
+import type { MetaFunction } from "@remix-run/node";
+import { FeedPage } from "pages/feed";
+
+export { loader } from "pages/feed";
+
+export const meta: MetaFunction = () => {
+  return [{ title: "Conduit" }];
+};
+
+export default FeedPage;
+```
+
+Và bước cuối cùng là render các card này trong feed. Cập nhật `FeedPage` của bạn với code sau:
+
+```tsx title="pages/feed/ui/FeedPage.tsx"
+import { useLoaderData } from "@remix-run/react";
+
+import type { loader } from "../api/loader";
+import { ArticlePreview } from "./ArticlePreview";
+
+export function FeedPage() {
+  const { articles } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="home-page">
+      <div className="banner">
+        <div className="container">
+          <h1 className="logo-font">conduit</h1>
+          <p>A place to share your knowledge.</p>
+        </div>
+      </div>
+
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-9">
+            {articles.articles.map((article) => (
+              <ArticlePreview key={article.slug} article={article} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+### Lọc theo tag
+
+Về các tag, công việc của chúng ta là lấy chúng từ backend và lưu trữ tag hiện tại được chọn. Chúng ta đã biết cách lấy — đó là một request khác từ loader. Chúng ta sẽ sử dụng function tiện lợi `promiseHash` từ package `remix-utils`, đã được cài đặt.
+
+Cập nhật file loader, `pages/feed/api/loader.ts`, với code sau:
+
+```tsx title="pages/feed/api/loader.ts"
+import { json } from "@remix-run/node";
+import type { FetchResponse } from "openapi-fetch";
+import { promiseHash } from "remix-utils/promise";
+
+import { GET } from "shared/api";
+
+async function throwAnyErrors<T, O, Media extends `${string}/${string}`>(
+  responsePromise: Promise<FetchResponse<T, O, Media>>,
+) {
+  const { data, error, response } = await responsePromise;
+
+  if (error !== undefined) {
+    throw json(error, { status: response.status });
+  }
+
+  return data as NonNullable<typeof data>;
+}
+
+export const loader = async () => {
+  return json(
+    await promiseHash({
+      articles: throwAnyErrors(GET("/articles")),
+      tags: throwAnyErrors(GET("/tags")),
+    }),
+  );
+};
+```
+
+Bạn có thể nhận thấy rằng chúng ta đã trích xuất xử lý lỗi thành function generic `throwAnyErrors`. Nó trông khá hữu ích, vì vậy chúng ta có thể muốn tái sử dụng nó sau, nhưng hiện tại hãy chỉ để mắt đến nó.
+
+Bây giờ, đến danh sách các tag. Nó cần phải tương tác — nhấp vào tag sẽ làm cho tag đó được chọn. Theo quy ước Remix, chúng ta sẽ sử dụng URL search parameter làm storage cho tag đã chọn. Để trình duyệt lo về storage trong khi chúng ta tập trung vào những thứ quan trọng hơn.
+
+Cập nhật `pages/feed/ui/FeedPage.tsx` với code sau:
+
+```tsx title="pages/feed/ui/FeedPage.tsx"
+import { Form, useLoaderData } from "@remix-run/react";
+import { ExistingSearchParams } from "remix-utils/existing-search-params";
+
+import type { loader } from "../api/loader";
+import { ArticlePreview } from "./ArticlePreview";
+
+export function FeedPage() {
+  const { articles, tags } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="home-page">
+      <div className="banner">
+        <div className="container">
+          <h1 className="logo-font">conduit</h1>
+          <p>A place to share your knowledge.</p>
+        </div>
+      </div>
+
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-9">
+            {articles.articles.map((article) => (
+              <ArticlePreview key={article.slug} article={article} />
+            ))}
+          </div>
+
+          <div className="col-md-3">
+            <div className="sidebar">
+              <p>Popular Tags</p>
+
+              <Form>
+                <ExistingSearchParams exclude={["tag"]} />
+                <div className="tag-list">
+                  {tags.tags.map((tag) => (
+                    <button
+                      key={tag}
+                      name="tag"
+                      value={tag}
+                      className="tag-pill tag-default"
+                    >
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+              </Form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+} 
+```
+
+Sau đó chúng ta cần sử dụng search parameter `tag` trong loader của chúng ta. Thay đổi function `loader` trong `pages/feed/api/loader.ts` thành như sau:
+
+```tsx title="pages/feed/api/loader.ts"
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import type { FetchResponse } from "openapi-fetch";
+import { promiseHash } from "remix-utils/promise";
+
+import { GET } from "shared/api";
+
+async function throwAnyErrors<T, O, Media extends `${string}/${string}`>(
+  responsePromise: Promise<FetchResponse<T, O, Media>>,
+) {
+  const { data, error, response } = await responsePromise;
+
+  if (error !== undefined) {
+    throw json(error, { status: response.status });
+  }
+
+  return data as NonNullable<typeof data>;
+}
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const selectedTag = url.searchParams.get("tag") ?? undefined;
+
+  return json(
+    await promiseHash({
+      articles: throwAnyErrors(
+        GET("/articles", { params: { query: { tag: selectedTag } } }),
+      ),
+      tags: throwAnyErrors(GET("/tags")),
+    }),
+  );
+};
+```
+
+Thế là xong, không cần segment `model`. Remix khá gọn gàng.
+
+### Phân trang
+
+Tương tự như vậy, chúng ta có thể triển khai phân trang. Hãy thoải mái thử tự làm hoặc chỉ copy code bên dưới. Dù sao cũng không ai phán xét bạn.
+
+```tsx title="pages/feed/api/loader.ts"
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import type { FetchResponse } from "openapi-fetch";
+import { promiseHash } from "remix-utils/promise";
+
+import { GET } from "shared/api";
+
+async function throwAnyErrors<T, O, Media extends `${string}/${string}`>(
+  responsePromise: Promise<FetchResponse<T, O, Media>>,
+) {
+  const { data, error, response } = await responsePromise;
+
+  if (error !== undefined) {
+    throw json(error, { status: response.status });
+  }
+
+  return data as NonNullable<typeof data>;
+}
+
+/** Amount of articles on one page. */
+export const LIMIT = 20;
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const selectedTag = url.searchParams.get("tag") ?? undefined;
+  const page = parseInt(url.searchParams.get("page") ?? "", 10);
+
+  return json(
+    await promiseHash({
+      articles: throwAnyErrors(
+        GET("/articles", {
+          params: {
+            query: {
+              tag: selectedTag,
+              limit: LIMIT,
+              offset: !Number.isNaN(page) ? page * LIMIT : undefined,
+            },
+          },
+        }),
+      ),
+      tags: throwAnyErrors(GET("/tags")),
+    }),
+  );
+};
+```
+
+```tsx title="pages/feed/ui/FeedPage.tsx"
+import { Form, useLoaderData, useSearchParams } from "@remix-run/react";
+import { ExistingSearchParams } from "remix-utils/existing-search-params";
+
+import { LIMIT, type loader } from "../api/loader";
+import { ArticlePreview } from "./ArticlePreview";
+
+export function FeedPage() {
+  const [searchParams] = useSearchParams();
+  const { articles, tags } = useLoaderData<typeof loader>();
+  const pageAmount = Math.ceil(articles.articlesCount / LIMIT);
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+
+  return (
+    <div className="home-page">
+      <div className="banner">
+        <div className="container">
+          <h1 className="logo-font">conduit</h1>
+          <p>A place to share your knowledge.</p>
+        </div>
+      </div>
+
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-9">
+            {articles.articles.map((article) => (
+              <ArticlePreview key={article.slug} article={article} />
+            ))}
+
+            <Form>
+              <ExistingSearchParams exclude={["page"]} />
+              <ul className="pagination">
+                {Array(pageAmount)
+                  .fill(null)
+                  .map((_, index) =>
+                    index + 1 === currentPage ? (
+                      <li key={index} className="page-item active">
+                        <span className="page-link">{index + 1}</span>
+                      </li>
+                    ) : (
+                      <li key={index} className="page-item">
+                        <button
+                          className="page-link"
+                          name="page"
+                          value={index + 1}
+                        >
+                          {index + 1}
+                        </button>
+                      </li>
+                    ),
+                  )}
+              </ul>
+            </Form>
+          </div>
+
+          <div className="col-md-3">
+            <div className="sidebar">
+              <p>Popular Tags</p>
+
+              <Form>
+                <ExistingSearchParams exclude={["tag", "page"]} />
+                <div className="tag-list">
+                  {tags.tags.map((tag) => (
+                    <button
+                      key={tag}
+                      name="tag"
+                      value={tag}
+                      className="tag-pill tag-default"
+                    >
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+              </Form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+Vậy là cũng xong rồi. Còn có danh sách tab có thể được triển khai tương tự, nhưng hãy đợi cho đến khi chúng ta triển khai authentication. Nói về điều đó!
+
+### Authentication
+
+Authentication liên quan đến hai trang — một để đăng nhập và một để đăng ký. Chúng hầu như giống nhau, vì vậy hợp lý khi giữ chúng trong cùng một slice, `sign-in`, để chúng có thể tái sử dụng code nếu cần.
+
+Tạo `RegisterPage.tsx` trong segment `ui` của `pages/sign-in` với nội dung sau:
+
+```tsx title="pages/sign-in/ui/RegisterPage.tsx"
+import { Form, Link, useActionData } from "@remix-run/react";
+
+import type { register } from "../api/register";
+
+export function RegisterPage() {
+  const registerData = useActionData<typeof register>();
+
+  return (
+    <div className="auth-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-6 offset-md-3 col-xs-12">
+            <h1 className="text-xs-center">Sign up</h1>
+            <p className="text-xs-center">
+              <Link to="/login">Have an account?</Link>
+            </p>
+
+            {registerData?.error && (
+              <ul className="error-messages">
+                {registerData.error.errors.body.map((error) => (
+                  <li key={error}>{error}</li>
+                ))}
+              </ul>
+            )}
+
+            <Form method="post">
+              <fieldset className="form-group">
+                <input
+                  className="form-control form-control-lg"
+                  type="text"
+                  name="username"
+                  placeholder="Username"
+                />
+              </fieldset>
+              <fieldset className="form-group">
+                <input
+                  className="form-control form-control-lg"
+                  type="text"
+                  name="email"
+                  placeholder="Email"
+                />
+              </fieldset>
+              <fieldset className="form-group">
+                <input
+                  className="form-control form-control-lg"
+                  type="password"
+                  name="password"
+                  placeholder="Password"
+                />
+              </fieldset>
+              <button className="btn btn-lg btn-primary pull-xs-right">
+                Sign up
+              </button>
+            </Form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+Chúng ta có một import bị lỗi cần sửa bây giờ. Nó liên quan đến một segment mới, vì vậy hãy tạo nó:
+
+```bash
+npx fsd pages sign-in -s api
+```
+
+Tuy nhiên, trước khi chúng ta có thể triển khai phần backend của đăng ký, chúng ta cần một số code infrastructure để Remix xử lý session. Điều đó thuộc về Shared, phòng khi trang nào khác cần nó.
+
+Đặt code sau vào `shared/api/auth.server.ts`. Đây là code rất cụ thể cho Remix, vì vậy đừng lo lắng quá nhiều về nó, chỉ cần copy-paste:
+
+```tsx title="shared/api/auth.server.ts"
+import { createCookieSessionStorage, redirect } from "@remix-run/node";
+import invariant from "tiny-invariant";
+
+import type { User } from "./models";
+
+invariant(
+  process.env.SESSION_SECRET,
+  "SESSION_SECRET must be set for authentication to work",
+);
+
+const sessionStorage = createCookieSessionStorage<{
+  user: User;
+}>({
+  cookie: {
+    name: "__session",
+    httpOnly: true,
+    path: "/",
+    sameSite: "lax",
+    secrets: [process.env.SESSION_SECRET],
+    secure: process.env.NODE_ENV === "production",
+  },
+});
+
+export async function createUserSession({
+  request,
+  user,
+  redirectTo,
+}: {
+  request: Request;
+  user: User;
+  redirectTo: string;
+}) {
+  const cookie = request.headers.get("Cookie");
+  const session = await sessionStorage.getSession(cookie);
+
+  session.set("user", user);
+
+  return redirect(redirectTo, {
+    headers: {
+      "Set-Cookie": await sessionStorage.commitSession(session, {
+        maxAge: 60 * 60 * 24 * 7, // 7 days
+      }),
+    },
+  });
+}
+
+export async function getUserFromSession(request: Request) {
+  const cookie = request.headers.get("Cookie");
+  const session = await sessionStorage.getSession(cookie);
+
+  return session.get("user") ?? null;
+}
+
+export async function requireUser(request: Request) {
+  const user = await getUserFromSession(request);
+
+  if (user === null) {
+    throw redirect("/login");
+  }
+
+  return user;
+}
+```
+
+Và cũng export model `User` từ file `models.ts` ngay cạnh nó:
+
+```tsx title="shared/api/models.ts"
+import type { components } from "./v1";
+
+export type Article = components["schemas"]["Article"];
+export type User = components["schemas"]["User"];
+```
+
+Trước khi code này có thể hoạt động, biến môi trường `SESSION_SECRET` cần được đặt. Tạo file tên `.env` trong thư mục gốc của dự án, viết `SESSION_SECRET=` và sau đó bấm một số phím trên bàn phím để tạo chuỗi ngẫu nhiên dài. Bạn sẽ có thứ gì đó như thế này:
+
+```bash title=".env"
+SESSION_SECRET=dontyoudarecopypastethis
+```
+
+Cuối cùng, thêm một số export vào public API để sử dụng code này:
+
+```tsx title="shared/api/index.ts"
+export { GET, POST, PUT, DELETE } from "./client";
+
+export type { Article } from "./models";
+
+export { createUserSession, getUserFromSession, requireUser } from "./auth.server";
+```
+
+Bây giờ chúng ta có thể viết code sẽ giao tiếp với RealWorld backend để thực sự thực hiện đăng ký. Chúng ta sẽ giữ điều đó trong `pages/sign-in/api`. Tạo file có tên `register.ts` và đặt code sau vào bên trong:
+
+```tsx title="pages/sign-in/api/register.ts"
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+
+import { POST, createUserSession } from "shared/api";
+
+export const register = async ({ request }: ActionFunctionArgs) => {
+  const formData = await request.formData();
+  const username = formData.get("username")?.toString() ?? "";
+  const email = formData.get("email")?.toString() ?? "";
+  const password = formData.get("password")?.toString() ?? "";
+
+  const { data, error } = await POST("/users", {
+    body: { user: { email, password, username } },
+  });
+
+  if (error) {
+    return json({ error }, { status: 400 });
+  } else {
+    return createUserSession({
+      request: request,
+      user: data.user,
+      redirectTo: "/",
+    });
+  }
+};
+```
+
+```tsx title="pages/sign-in/index.ts"
+export { RegisterPage } from './ui/RegisterPage';
+export { register } from './api/register';
+```
+
+Gần xong rồi! Chỉ cần kết nối trang và action với route `/register`. Tạo `register.tsx` trong `app/routes`:
+
+```tsx title="app/routes/register.tsx"
+import { RegisterPage, register } from "pages/sign-in";
+
+export { register as action };
+
+export default RegisterPage;
+```
+
+Bây giờ nếu bạn đi đến [http://localhost:3000/register](http://localhost:3000/register), bạn sẽ có thể tạo người dùng! Phần còn lại của ứng dụng sẽ chưa phản ứng với điều này, chúng ta sẽ giải quyết điều đó ngay.
+
+Tương tự như vậy, chúng ta có thể triển khai trang đăng nhập. Hãy thử hoặc chỉ lấy code và tiếp tục:
+
+```tsx title="pages/sign-in/api/sign-in.ts"
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+
+import { POST, createUserSession } from "shared/api";
+
+export const signIn = async ({ request }: ActionFunctionArgs) => {
+  const formData = await request.formData();
+  const email = formData.get("email")?.toString() ?? "";
+  const password = formData.get("password")?.toString() ?? "";
+
+  const { data, error } = await POST("/users/login", {
+    body: { user: { email, password } },
+  });
+
+  if (error) {
+    return json({ error }, { status: 400 });
+  } else {
+    return createUserSession({
+      request: request,
+      user: data.user,
+      redirectTo: "/",
+    });
+  }
+};
+```
+
+```tsx title="pages/sign-in/ui/SignInPage.tsx"
+import { Form, Link, useActionData } from "@remix-run/react";
+
+import type { signIn } from "../api/sign-in";
+
+export function SignInPage() {
+  const signInData = useActionData<typeof signIn>();
+
+  return (
+    <div className="auth-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-6 offset-md-3 col-xs-12">
+            <h1 className="text-xs-center">Sign in</h1>
+            <p className="text-xs-center">
+              <Link to="/register">Need an account?</Link>
+            </p>
+
+            {signInData?.error && (
+              <ul className="error-messages">
+                {signInData.error.errors.body.map((error) => (
+                  <li key={error}>{error}</li>
+                ))}
+              </ul>
+            )}
+
+            <Form method="post">
+              <fieldset className="form-group">
+                <input
+                  className="form-control form-control-lg"
+                  name="email"
+                  type="text"
+                  placeholder="Email"
+                />
+              </fieldset>
+              <fieldset className="form-group">
+                <input
+                  className="form-control form-control-lg"
+                  name="password"
+                  type="password"
+                  placeholder="Password"
+                />
+              </fieldset>
+              <button className="btn btn-lg btn-primary pull-xs-right">
+                Sign in
+              </button>
+            </Form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+```tsx title="pages/sign-in/index.ts"
+export { RegisterPage } from './ui/RegisterPage';
+export { register } from './api/register';
+export { SignInPage } from './ui/SignInPage';
+export { signIn } from './api/sign-in';
+```
+
+```tsx title="app/routes/login.tsx"
+import { SignInPage, signIn } from "pages/sign-in";
+
+export { signIn as action };
+
+export default SignInPage;
+```
+
+Bây giờ hãy cung cấp cho người dùng cách thực sự đến các trang này.
+
+### Header
+
+Như chúng ta đã thảo luận trong phần 1, header app thường được đặt trong Widgets hoặc trong Shared. Chúng ta sẽ đặt nó trong Shared vì nó rất đơn giản và tất cả business logic có thể được giữ bên ngoài nó. Hãy tạo chỗ cho nó:
+
+```bash
+npx fsd shared ui
+```
+
+Bây giờ tạo `shared/ui/Header.tsx` với nội dung sau:
+
+```tsx title="shared/ui/Header.tsx"
+import { useContext } from "react";
+import { Link, useLocation } from "@remix-run/react";
+
+import { CurrentUser } from "../api/currentUser";
+
+export function Header() {
+  const currentUser = useContext(CurrentUser);
+  const { pathname } = useLocation();
+
+  return (
+    <nav className="navbar navbar-light">
+      <div className="container">
+        <Link className="navbar-brand" to="/" prefetch="intent">
+          conduit
+        </Link>
+        <ul className="nav navbar-nav pull-xs-right">
+          <li className="nav-item">
+            <Link
+              prefetch="intent"
+              className={`nav-link ${pathname == "/" ? "active" : ""}`}
+              to="/"
+            >
+              Home
+            </Link>
+          </li>
+          {currentUser == null ? (
+            <>
+              <li className="nav-item">
+                <Link
+                  prefetch="intent"
+                  className={`nav-link ${pathname == "/login" ? "active" : ""}`}
+                  to="/login"
+                >
+                  Sign in
+                </Link>
+              </li>
+              <li className="nav-item">
+                <Link
+                  prefetch="intent"
+                  className={`nav-link ${pathname == "/register" ? "active" : ""}`}
+                  to="/register"
+                >
+                  Sign up
+                </Link>
+              </li>
+            </>
+          ) : (
+            <>
+              <li className="nav-item">
+                <Link
+                  prefetch="intent"
+                  className={`nav-link ${pathname == "/editor" ? "active" : ""}`}
+                  to="/editor"
+                >
+                  <i className="ion-compose"></i>&nbsp;New Article{" "}
+                </Link>
+              </li>
+
+              <li className="nav-item">
+                <Link
+                  prefetch="intent"
+                  className={`nav-link ${pathname == "/settings" ? "active" : ""}`}
+                  to="/settings"
+                >
+                  {" "}
+                  <i className="ion-gear-a"></i>&nbsp;Settings{" "}
+                </Link>
+              </li>
+              <li className="nav-item">
+                <Link
+                  prefetch="intent"
+                  className={`nav-link ${pathname.includes("/profile") ? "active" : ""}`}
+                  to={`/profile/${currentUser.username}`}
+                >
+                  {currentUser.image && (
+                    <img
+                      width={25}
+                      height={25}
+                      src={currentUser.image}
+                      className="user-pic"
+                      alt=""
+                    />
+                  )}
+                  {currentUser.username}
+                </Link>
+              </li>
+            </>
+          )}
+        </ul>
+      </div>
+    </nav>
+  );
+}
+```
+
+Export component này từ `shared/ui`:
+
+```tsx title="shared/ui/index.ts"
+export { Header } from "./Header";
+```
+
+Trong header, chúng ta dựa vào context được giữ trong `shared/api`. Cũng tạo điều đó:
+
+```tsx title="shared/api/currentUser.ts"
+import { createContext } from "react";
+
+import type { User } from "./models";
+
+export const CurrentUser = createContext<User | null>(null);
+```
+
+```tsx title="shared/api/index.ts"
+export { GET, POST, PUT, DELETE } from "./client";
+
+export type { Article } from "./models";
+
+export { createUserSession, getUserFromSession, requireUser } from "./auth.server";
+export { CurrentUser } from "./currentUser";
+```
+
+Bây giờ hãy thêm header vào trang. Chúng ta muốn nó có trên mọi trang, vì vậy hợp lý khi chỉ thêm nó vào root route và wrap outlet (nơi trang sẽ được render) với provider context `CurrentUser`. Theo cách này, toàn bộ app của chúng ta và cả header đều có quyền truy cập vào object người dùng hiện tại. Chúng ta cũng sẽ thêm loader để thực sự lấy object người dùng hiện tại từ cookie. Đặt nội dung sau vào `app/root.tsx`:
+
+```tsx title="app/root.tsx"
+import { cssBundleHref } from "@remix-run/css-bundle";
+import type { LinksFunction, LoaderFunctionArgs } from "@remix-run/node";
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+  useLoaderData,
+} from "@remix-run/react";
+
+import { Header } from "shared/ui";
+import { getUserFromSession, CurrentUser } from "shared/api";
+
+export const links: LinksFunction = () => [
+  ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),
+];
+
+export const loader = ({ request }: LoaderFunctionArgs) =>
+  getUserFromSession(request);
+
+export default function App() {
+  const user = useLoaderData<typeof loader>();
+
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <Meta />
+        <Links />
+        <link
+          href="//code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css"
+          rel="stylesheet"
+          type="text/css"
+        />
+        <link
+          href="//fonts.googleapis.com/css?family=Titillium+Web:700|Source+Serif+Pro:400,700|Merriweather+Sans:400,700|Source+Sans+Pro:400,300,600,700,300italic,400italic,600italic,700italic"
+          rel="stylesheet"
+          type="text/css"
+        />
+        <link rel="stylesheet" href="//demo.productionready.io/main.css" />
+        <style>{`
+          button {
+            border: 0;
+          }
+        `}</style>
+      </head>
+      <body>
+        <CurrentUser.Provider value={user}>
+          <Header />
+          <Outlet />
+        </CurrentUser.Provider>
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+```
+
+Tại thời điểm này, bạn sẽ có kết quả sau trên trang chủ:
+
+<figure>
+  ![The feed page of Conduit, including the header, the feed, and the tags. The tabs are still missing.](/img/tutorial/realworld-feed-without-tabs.jpg)
+
+  <figcaption>Trang feed của Conduit, bao gồm header, feed, và các tag. Các tab vẫn còn thiếu.</figcaption>
+</figure>
+
+### Tab
+
+Bây giờ chúng ta có thể phát hiện trạng thái authentication, hãy cũng nhanh chóng triển khai các tab và like bài viết để hoàn thành trang feed. Chúng ta cần một form khác, nhưng file trang này đang trở nên khá lớn, vì vậy hãy chuyển những form này vào các file liền kề. Chúng ta sẽ tạo `Tabs.tsx`, `PopularTags.tsx`, và `Pagination.tsx` với nội dung sau:
+
+```tsx title="pages/feed/ui/Tabs.tsx"
+import { useContext } from "react";
+import { Form, useSearchParams } from "@remix-run/react";
+
+import { CurrentUser } from "shared/api";
+
+export function Tabs() {
+  const [searchParams] = useSearchParams();
+  const currentUser = useContext(CurrentUser);
+
+  return (
+    <Form>
+      <div className="feed-toggle">
+        <ul className="nav nav-pills outline-active">
+          {currentUser !== null && (
+            <li className="nav-item">
+              <button
+                name="source"
+                value="my-feed"
+                className={`nav-link ${searchParams.get("source") === "my-feed" ? "active" : ""}`}
+              >
+                Your Feed
+              </button>
+            </li>
+          )}
+          <li className="nav-item">
+            <button
+              className={`nav-link ${searchParams.has("tag") || searchParams.has("source") ? "" : "active"}`}
+            >
+              Global Feed
+            </button>
+          </li>
+          {searchParams.has("tag") && (
+            <li className="nav-item">
+              <span className="nav-link active">
+                <i className="ion-pound"></i> {searchParams.get("tag")}
+              </span>
+            </li>
+          )}
+        </ul>
+      </div>
+    </Form>
+  );
+}
+```
+
+```tsx title="pages/feed/ui/PopularTags.tsx"
+import { Form, useLoaderData } from "@remix-run/react";
+import { ExistingSearchParams } from "remix-utils/existing-search-params";
+
+import type { loader } from "../api/loader";
+
+export function PopularTags() {
+  const { tags } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="sidebar">
+      <p>Popular Tags</p>
+
+      <Form>
+        <ExistingSearchParams exclude={["tag", "page", "source"]} />
+        <div className="tag-list">
+          {tags.tags.map((tag) => (
+            <button
+              key={tag}
+              name="tag"
+              value={tag}
+              className="tag-pill tag-default"
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      </Form>
+    </div>
+  );
+}
+```
+
+```tsx title="pages/feed/ui/Pagination.tsx"
+import { Form, useLoaderData, useSearchParams } from "@remix-run/react";
+import { ExistingSearchParams } from "remix-utils/existing-search-params";
+
+import { LIMIT, type loader } from "../api/loader";
+
+export function Pagination() {
+  const [searchParams] = useSearchParams();
+  const { articles } = useLoaderData<typeof loader>();
+  const pageAmount = Math.ceil(articles.articlesCount / LIMIT);
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+
+  return (
+    <Form>
+      <ExistingSearchParams exclude={["page"]} />
+      <ul className="pagination">
+        {Array(pageAmount)
+          .fill(null)
+          .map((_, index) =>
+            index + 1 === currentPage ? (
+              <li key={index} className="page-item active">
+                <span className="page-link">{index + 1}</span>
+              </li>
+            ) : (
+              <li key={index} className="page-item">
+                <button className="page-link" name="page" value={index + 1}>
+                  {index + 1}
+                </button>
+              </li>
+            ),
+          )}
+      </ul>
+    </Form>
+  );
+}
+```
+
+Và bây giờ chúng ta có thể đơn giản hóa đáng kể chính trang feed:
+
+```tsx title="pages/feed/ui/FeedPage.tsx"
+import { useLoaderData } from "@remix-run/react";
+
+import type { loader } from "../api/loader";
+import { ArticlePreview } from "./ArticlePreview";
+import { Tabs } from "./Tabs";
+import { PopularTags } from "./PopularTags";
+import { Pagination } from "./Pagination";
+
+export function FeedPage() {
+  const { articles } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="home-page">
+      <div className="banner">
+        <div className="container">
+          <h1 className="logo-font">conduit</h1>
+          <p>A place to share your knowledge.</p>
+        </div>
+      </div>
+
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-9">
+            <Tabs />
+
+            {articles.articles.map((article) => (
+              <ArticlePreview key={article.slug} article={article} />
+            ))}
+
+            <Pagination />
+          </div>
+
+          <div className="col-md-3">
+            <PopularTags />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+Chúng ta cũng cần tính đến tab mới trong function loader:
+
+```tsx title="pages/feed/api/loader.ts"
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import type { FetchResponse } from "openapi-fetch";
+import { promiseHash } from "remix-utils/promise";
+
+import { GET, requireUser } from "shared/api";
+
+async function throwAnyErrors<T, O, Media extends `${string}/${string}`>(
+  responsePromise: Promise<FetchResponse<T, O, Media>>,
+) {
+  /* unchanged */
+}
+
+/** Amount of articles on one page. */
+export const LIMIT = 20;
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const selectedTag = url.searchParams.get("tag") ?? undefined;
+  const page = parseInt(url.searchParams.get("page") ?? "", 10);
+
+  if (url.searchParams.get("source") === "my-feed") {
+    const userSession = await requireUser(request);
+
+    return json(
+      await promiseHash({
+        articles: throwAnyErrors(
+          GET("/articles/feed", {
+            params: {
+              query: {
+                limit: LIMIT,
+                offset: !Number.isNaN(page) ? page * LIMIT : undefined,
+              },
+            },
+            headers: { Authorization: `Token ${userSession.token}` },
+          }),
+        ),
+        tags: throwAnyErrors(GET("/tags")),
+      }),
+    );
+  }
+
+  return json(
+    await promiseHash({
+      articles: throwAnyErrors(
+        GET("/articles", {
+          params: {
+            query: {
+              tag: selectedTag,
+              limit: LIMIT,
+              offset: !Number.isNaN(page) ? page * LIMIT : undefined,
+            },
+          },
+        }),
+      ),
+      tags: throwAnyErrors(GET("/tags")),
+    }),
+  );
+};
+```
+
+Trước khi rời trang feed, hãy thêm một số code xử lý like cho bài viết. Thay đổi `ArticlePreview.tsx` của bạn thành như sau:
+
+```tsx title="pages/feed/ui/ArticlePreview.tsx"
+import { Form, Link } from "@remix-run/react";
+import type { Article } from "shared/api";
+
+interface ArticlePreviewProps {
+  article: Article;
+}
+
+export function ArticlePreview({ article }: ArticlePreviewProps) {
+  return (
+    <div className="article-preview">
+      <div className="article-meta">
+        <Link to={`/profile/${article.author.username}`} prefetch="intent">
+          <img src={article.author.image} alt="" />
+        </Link>
+        <div className="info">
+          <Link
+            to={`/profile/${article.author.username}`}
+            className="author"
+            prefetch="intent"
+          >
+            {article.author.username}
+          </Link>
+          <span className="date" suppressHydrationWarning>
+            {new Date(article.createdAt).toLocaleDateString(undefined, {
+              dateStyle: "long",
+            })}
+          </span>
+        </div>
+        <Form
+          method="post"
+          action={`/article/${article.slug}`}
+          preventScrollReset
+        >
+          <button
+            name="_action"
+            value={article.favorited ? "unfavorite" : "favorite"}
+            className={`btn ${article.favorited ? "btn-primary" : "btn-outline-primary"} btn-sm pull-xs-right`}
+          >
+            <i className="ion-heart"></i> {article.favoritesCount}
+          </button>
+        </Form>
+      </div>
+      <Link
+        to={`/article/${article.slug}`}
+        className="preview-link"
+        prefetch="intent"
+      >
+        <h1>{article.title}</h1>
+        <p>{article.description}</p>
+        <span>Read more...</span>
+        <ul className="tag-list">
+          {article.tagList.map((tag) => (
+            <li key={tag} className="tag-default tag-pill tag-outline">
+              {tag}
+            </li>
+          ))}
+        </ul>
+      </Link>
+    </div>
+  );
+}
+```
+
+Code này sẽ gửi POST request đến `/article/:slug` với `_action=favorite` để đánh dấu article là yêu thích. Nó chưa hoạt động, nhưng khi chúng ta bắt đầu làm việc trên trình đọc article, chúng ta cũng sẽ triển khai điều này.
+
+Và với điều đó, chúng ta đã chính thức hoàn thành feed! Yay!
+
+### Trình đọc article
+
+Trước tiên, chúng ta cần dữ liệu. Hãy tạo một loader:
+
+```bash
+npx fsd pages article-read -s api
+```
+
+```tsx title="pages/article-read/api/loader.ts"
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import invariant from "tiny-invariant";
+import type { FetchResponse } from "openapi-fetch";
+import { promiseHash } from "remix-utils/promise";
+
+import { GET, getUserFromSession } from "shared/api";
+
+async function throwAnyErrors<T, O, Media extends `${string}/${string}`>(
+  responsePromise: Promise<FetchResponse<T, O, Media>>,
+) {
+  const { data, error, response } = await responsePromise;
+
+  if (error !== undefined) {
+    throw json(error, { status: response.status });
+  }
+
+  return data as NonNullable<typeof data>;
+}
+
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
+  invariant(params.slug, "Expected a slug parameter");
+  const currentUser = await getUserFromSession(request);
+  const authorization = currentUser
+    ? { Authorization: `Token ${currentUser.token}` }
+    : undefined;
+
+  return json(
+    await promiseHash({
+      article: throwAnyErrors(
+        GET("/articles/{slug}", {
+          params: {
+            path: { slug: params.slug },
+          },
+          headers: authorization,
+        }),
+      ),
+      comments: throwAnyErrors(
+        GET("/articles/{slug}/comments", {
+          params: {
+            path: { slug: params.slug },
+          },
+          headers: authorization,
+        }),
+      ),
+    }),
+  );
+};
+```
+
+```tsx title="pages/article-read/index.ts"
+export { loader } from "./api/loader";
+```
+
+Bây giờ chúng ta có thể kết nối nó với route `/article/:slug` bằng cách tạo file route có tên `article.$slug.tsx`:
+
+```tsx title="app/routes/article.$slug.tsx"
+export { loader } from "pages/article-read";
+```
+
+Chính trang bao gồm ba khối chính — header article với các action (lặp lại hai lần), nội dung article, và phần comment. Đây là markup cho trang, nó không đặc biệt thú vị:
+
+```tsx title="pages/article-read/ui/ArticleReadPage.tsx"
+import { useLoaderData } from "@remix-run/react";
+
+import type { loader } from "../api/loader";
+import { ArticleMeta } from "./ArticleMeta";
+import { Comments } from "./Comments";
+
+export function ArticleReadPage() {
+  const { article } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="article-page">
+      <div className="banner">
+        <div className="container">
+          <h1>{article.article.title}</h1>
+
+          <ArticleMeta />
+        </div>
+      </div>
+
+      <div className="container page">
+        <div className="row article-content">
+          <div className="col-md-12">
+            <p>{article.article.body}</p>
+            <ul className="tag-list">
+              {article.article.tagList.map((tag) => (
+                <li className="tag-default tag-pill tag-outline" key={tag}>
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <hr />
+
+        <div className="article-actions">
+          <ArticleMeta />
+        </div>
+
+        <div className="row">
+          <Comments />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+Điều thú vị hơn là `ArticleMeta` và `Comments`. Chúng chứa các thao tác ghi như thích article, để lại comment, v.v. Để chúng hoạt động, trước tiên chúng ta cần triển khai phần backend. Tạo `action.ts` trong segment `api` của trang:
+
+```tsx title="pages/article-read/api/action.ts"
+import { redirect, type ActionFunctionArgs } from "@remix-run/node";
+import { namedAction } from "remix-utils/named-action";
+import { redirectBack } from "remix-utils/redirect-back";
+import invariant from "tiny-invariant";
+
+import { DELETE, POST, requireUser } from "shared/api";
+
+export const action = async ({ request, params }: ActionFunctionArgs) => {
+  const currentUser = await requireUser(request);
+
+  const authorization = { Authorization: `Token ${currentUser.token}` };
+
+  const formData = await request.formData();
+
+  return namedAction(formData, {
+    async delete() {
+      invariant(params.slug, "Expected a slug parameter");
+      await DELETE("/articles/{slug}", {
+        params: { path: { slug: params.slug } },
+        headers: authorization,
+      });
+      return redirect("/");
+    },
+    async favorite() {
+      invariant(params.slug, "Expected a slug parameter");
+      await POST("/articles/{slug}/favorite", {
+        params: { path: { slug: params.slug } },
+        headers: authorization,
+      });
+      return redirectBack(request, { fallback: "/" });
+    },
+    async unfavorite() {
+      invariant(params.slug, "Expected a slug parameter");
+      await DELETE("/articles/{slug}/favorite", {
+        params: { path: { slug: params.slug } },
+        headers: authorization,
+      });
+      return redirectBack(request, { fallback: "/" });
+    },
+    async createComment() {
+      invariant(params.slug, "Expected a slug parameter");
+      const comment = formData.get("comment");
+      invariant(typeof comment === "string", "Expected a comment parameter");
+      await POST("/articles/{slug}/comments", {
+        params: { path: { slug: params.slug } },
+        headers: { ...authorization, "Content-Type": "application/json" },
+        body: { comment: { body: comment } },
+      });
+      return redirectBack(request, { fallback: "/" });
+    },
+    async deleteComment() {
+      invariant(params.slug, "Expected a slug parameter");
+      const commentId = formData.get("id");
+      invariant(typeof commentId === "string", "Expected an id parameter");
+      const commentIdNumeric = parseInt(commentId, 10);
+      invariant(
+        !Number.isNaN(commentIdNumeric),
+        "Expected a numeric id parameter",
+      );
+      await DELETE("/articles/{slug}/comments/{id}", {
+        params: { path: { slug: params.slug, id: commentIdNumeric } },
+        headers: authorization,
+      });
+      return redirectBack(request, { fallback: "/" });
+    },
+    async followAuthor() {
+      const authorUsername = formData.get("username");
+      invariant(
+        typeof authorUsername === "string",
+        "Expected a username parameter",
+      );
+      await POST("/profiles/{username}/follow", {
+        params: { path: { username: authorUsername } },
+        headers: authorization,
+      });
+      return redirectBack(request, { fallback: "/" });
+    },
+    async unfollowAuthor() {
+      const authorUsername = formData.get("username");
+      invariant(
+        typeof authorUsername === "string",
+        "Expected a username parameter",
+      );
+      await DELETE("/profiles/{username}/follow", {
+        params: { path: { username: authorUsername } },
+        headers: authorization,
+      });
+      return redirectBack(request, { fallback: "/" });
+    },
+  });
+};
+```
+
+Export điều đó từ slice và sau đó từ route. Trong khi làm điều đó, hãy cũng kết nối chính trang:
+
+```tsx title="pages/article-read/index.ts"
+export { ArticleReadPage } from "./ui/ArticleReadPage";
+export { loader } from "./api/loader";
+export { action } from "./api/action";
+```
+
+```tsx title="app/routes/article.$slug.tsx"
+import { ArticleReadPage } from "pages/article-read";
+
+export { loader, action } from "pages/article-read";
+
+export default ArticleReadPage;
+```
+
+Bây giờ, mặc dù chúng ta chưa triển khai button like trên trang đọc, button like trong feed sẽ bắt đầu hoạt động! Đó là vì nó đã gửi request "like" đến route này. Hãy thử điều đó.
+
+`ArticleMeta` và `Comments`, một lần nữa, là một loạt form. Chúng ta đã làm điều này trước đây, hãy lấy code của chúng và tiếp tục:
+
+```tsx title="pages/article-read/ui/ArticleMeta.tsx"
+import { Form, Link, useLoaderData } from "@remix-run/react";
+import { useContext } from "react";
+
+import { CurrentUser } from "shared/api";
+import type { loader } from "../api/loader";
+
+export function ArticleMeta() {
+  const currentUser = useContext(CurrentUser);
+  const { article } = useLoaderData<typeof loader>();
+
+  return (
+    <Form method="post">
+      <div className="article-meta">
+        <Link
+          prefetch="intent"
+          to={`/profile/${article.article.author.username}`}
+        >
+          <img src={article.article.author.image} alt="" />
+        </Link>
+
+        <div className="info">
+          <Link
+            prefetch="intent"
+            to={`/profile/${article.article.author.username}`}
+            className="author"
+          >
+            {article.article.author.username}
+          </Link>
+          <span className="date">{article.article.createdAt}</span>
+        </div>
+
+        {article.article.author.username == currentUser?.username ? (
+          <>
+            <Link
+              prefetch="intent"
+              to={`/editor/${article.article.slug}`}
+              className="btn btn-sm btn-outline-secondary"
+            >
+              <i className="ion-edit"></i> Edit Article
+            </Link>
+            &nbsp;&nbsp;
+            <button
+              name="_action"
+              value="delete"
+              className="btn btn-sm btn-outline-danger"
+            >
+              <i className="ion-trash-a"></i> Delete Article
+            </button>
+          </>
+        ) : (
+          <>
+            <input
+              name="username"
+              value={article.article.author.username}
+              type="hidden"
+            />
+            <button
+              name="_action"
+              value={
+                article.article.author.following
+                  ? "unfollowAuthor"
+                  : "followAuthor"
+              }
+              className={`btn btn-sm ${article.article.author.following ? "btn-secondary" : "btn-outline-secondary"}`}
+            >
+              <i className="ion-plus-round"></i>
+              &nbsp;{" "}
+              {article.article.author.following
+                ? "Unfollow"
+                : "Follow"}{" "}
+              {article.article.author.username}
+            </button>
+            &nbsp;&nbsp;
+            <button
+              name="_action"
+              value={article.article.favorited ? "unfavorite" : "favorite"}
+              className={`btn btn-sm ${article.article.favorited ? "btn-primary" : "btn-outline-primary"}`}
+            >
+              <i className="ion-heart"></i>
+              &nbsp; {article.article.favorited
+                ? "Unfavorite"
+                : "Favorite"}{" "}
+              Post{" "}
+              <span className="counter">
+                ({article.article.favoritesCount})
+              </span>
+            </button>
+          </>
+        )}
+      </div>
+    </Form>
+  );
+}
+```
+
+```tsx title="pages/article-read/ui/Comments.tsx"
+import { useContext } from "react";
+import { Form, Link, useLoaderData } from "@remix-run/react";
+
+import { CurrentUser } from "shared/api";
+import type { loader } from "../api/loader";
+
+export function Comments() {
+  const { comments } = useLoaderData<typeof loader>();
+  const currentUser = useContext(CurrentUser);
+
+  return (
+    <div className="col-xs-12 col-md-8 offset-md-2">
+      {currentUser !== null ? (
+        <Form
+          preventScrollReset={true}
+          method="post"
+          className="card comment-form"
+        >
+          <div className="card-block">
+            <textarea
+              required
+              className="form-control"
+              name="comment"
+              placeholder="Write a comment..."
+              rows={3}
+            ></textarea>
+          </div>
+          <div className="card-footer">
+            <img
+              src={currentUser.image}
+              className="comment-author-img"
+              alt=""
+            />
+            <button
+              className="btn btn-sm btn-primary"
+              name="_action"
+              value="createComment"
+            >
+              Post Comment
+            </button>
+          </div>
+        </Form>
+      ) : (
+        <div className="row">
+          <div className="col-xs-12 col-md-8 offset-md-2">
+            <p>
+              <Link to="/login">Sign in</Link>
+              &nbsp; or &nbsp;
+              <Link to="/register">Sign up</Link>
+              &nbsp; to add comments on this article.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {comments.comments.map((comment) => (
+        <div className="card" key={comment.id}>
+          <div className="card-block">
+            <p className="card-text">{comment.body}</p>
+          </div>
+
+          <div className="card-footer">
+            <Link
+              to={`/profile/${comment.author.username}`}
+              className="comment-author"
+            >
+              <img
+                src={comment.author.image}
+                className="comment-author-img"
+                alt=""
+              />
+            </Link>
+            &nbsp;
+            <Link
+              to={`/profile/${comment.author.username}`}
+              className="comment-author"
+            >
+              {comment.author.username}
+            </Link>
+            <span className="date-posted">{comment.createdAt}</span>
+            {comment.author.username === currentUser?.username && (
+              <span className="mod-options">
+                <Form method="post" preventScrollReset={true}>
+                  <input type="hidden" name="id" value={comment.id} />
+                  <button
+                    name="_action"
+                    value="deleteComment"
+                    style={{
+                      border: "none",
+                      outline: "none",
+                      backgroundColor: "transparent",
+                    }}
+                  >
+                    <i className="ion-trash-a"></i>
+                  </button>
+                </Form>
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+Và với điều đó, trình đọc article của chúng ta cũng hoàn thành! Các button theo dõi tác giả, thích bài viết, và để lại comment giờ đây sẽ hoạt động như mong đợi.
+
+<figure>
+  ![Article reader with functioning buttons to like and follow](/img/tutorial/realworld-article-reader.jpg)
+
+  <figcaption>Trình đọc article với các button hoạt động để thích và theo dõi</figcaption>
+</figure>
+
+### Trình chỉnh sửa article
+
+Đây là trang cuối cùng mà chúng ta sẽ đề cập trong tutorial này, và phần thú vị nhất ở đây là cách chúng ta sẽ validate dữ liệu form.
+
+Chính trang, `article-edit/ui/ArticleEditPage.tsx`, sẽ khá đơn giản, độ phức tạp bổ sung được cất giấu trong hai component khác:
+
+```tsx title="pages/article-edit/ui/ArticleEditPage.tsx"
+import { Form, useLoaderData } from "@remix-run/react";
+
+import type { loader } from "../api/loader";
+import { TagsInput } from "./TagsInput";
+import { FormErrors } from "./FormErrors";
+
+export function ArticleEditPage() {
+  const article = useLoaderData<typeof loader>();
+
+  return (
+    <div className="editor-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-10 offset-md-1 col-xs-12">
+            <FormErrors />
+
+            <Form method="post">
+              <fieldset>
+                <fieldset className="form-group">
+                  <input
+                    type="text"
+                    className="form-control form-control-lg"
+                    name="title"
+                    placeholder="Article Title"
+                    defaultValue={article.article?.title}
+                  />
+                </fieldset>
+                <fieldset className="form-group">
+                  <input
+                    type="text"
+                    className="form-control"
+                    name="description"
+                    placeholder="What's this article about?"
+                    defaultValue={article.article?.description}
+                  />
+                </fieldset>
+                <fieldset className="form-group">
+                  <textarea
+                    className="form-control"
+                    name="body"
+                    rows={8}
+                    placeholder="Write your article (in markdown)"
+                    defaultValue={article.article?.body}
+                  ></textarea>
+                </fieldset>
+                <fieldset className="form-group">
+                  <TagsInput
+                    name="tags"
+                    defaultValue={article.article?.tagList ?? []}
+                  />
+                </fieldset>
+
+                <button className="btn btn-lg pull-xs-right btn-primary">
+                  Publish Article
+                </button>
+              </fieldset>
+            </Form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+Trang này lấy article hiện tại (trừ khi chúng ta viết từ đầu) và điền vào các trường form tương ứng. Chúng ta đã thấy điều này trước đây. Phần thú vị là `FormErrors`, vì nó sẽ nhận kết quả validation và hiển thị cho người dùng. Hãy xem:
+
+```tsx title="pages/article-edit/ui/FormErrors.tsx"
+import { useActionData } from "@remix-run/react";
+import type { action } from "../api/action";
+
+export function FormErrors() {
+  const actionData = useActionData<typeof action>();
+
+  return actionData?.errors != null ? (
+    <ul className="error-messages">
+      {actionData.errors.map((error) => (
+        <li key={error}>{error}</li>
+      ))}
+    </ul>
+  ) : null;
+}
+```
+
+Ở đây chúng ta giả định rằng action của chúng ta sẽ trả về trường `errors`, một mảng các thông báo lỗi có thể đọc được. Chúng ta sẽ đến action ngay.
+
+Component khác là input tag. Nó chỉ là trường input đơn giản với preview bổ sung của các tag đã chọn. Không có gì nhiều để xem ở đây:
+
+```tsx title="pages/article-edit/ui/TagsInput.tsx"
+import { useEffect, useRef, useState } from "react";
+
+export function TagsInput({
+  name,
+  defaultValue,
+}: {
+  name: string;
+  defaultValue?: Array<string>;
+}) {
+  const [tagListState, setTagListState] = useState(defaultValue ?? []);
+
+  function removeTag(tag: string): void {
+    const newTagList = tagListState.filter((t) => t !== tag);
+    setTagListState(newTagList);
+  }
+
+  const tagsInput = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    tagsInput.current && (tagsInput.current.value = tagListState.join(","));
+  }, [tagListState]);
+
+  return (
+    <>
+      <input
+        type="text"
+        className="form-control"
+        id="tags"
+        name={name}
+        placeholder="Enter tags"
+        defaultValue={tagListState.join(",")}
+        onChange={(e) =>
+          setTagListState(e.target.value.split(",").filter(Boolean))
+        }
+      />
+      <div className="tag-list">
+        {tagListState.map((tag) => (
+          <span className="tag-default tag-pill" key={tag}>
+            <i
+              className="ion-close-round"
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) =>
+                [" ", "Enter"].includes(e.key) && removeTag(tag)
+              }
+              onClick={() => removeTag(tag)}
+            ></i>{" "}
+            {tag}
+          </span>
+        ))}
+      </div>
+    </>
+  );
+}
+```
+
+Bây giờ, cho phần API. Loader nên nhìn vào URL, và nếu nó chứa article slug, có nghĩa là chúng ta đang chỉnh sửa article hiện có, và dữ liệu của nó nên được tải. Nếu không, trả về không có gì. Hãy tạo loader đó:
+
+```ts title="pages/article-edit/api/loader.ts"
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import type { FetchResponse } from "openapi-fetch";
+
+import { GET, requireUser } from "shared/api";
+
+async function throwAnyErrors<T, O, Media extends `${string}/${string}`>(
+  responsePromise: Promise<FetchResponse<T, O, Media>>,
+) {
+  const { data, error, response } = await responsePromise;
+
+  if (error !== undefined) {
+    throw json(error, { status: response.status });
+  }
+
+  return data as NonNullable<typeof data>;
+}
+
+export const loader = async ({ params, request }: LoaderFunctionArgs) => {
+  const currentUser = await requireUser(request);
+
+  if (!params.slug) {
+    return { article: null };
+  }
+
+  return throwAnyErrors(
+    GET("/articles/{slug}", {
+      params: { path: { slug: params.slug } },
+      headers: { Authorization: `Token ${currentUser.token}` },
+    }),
+  );
+};
+```
+
+Action sẽ lấy các giá trị trường mới, chạy chúng qua data schema của chúng ta, và nếu mọi thứ đều đúng, commit những thay đổi đó đến backend, hoặc bằng cách cập nhật article hiện có hoặc tạo một article mới:
+
+```tsx title="pages/article-edit/api/action.ts"
+import { json, redirect, type ActionFunctionArgs } from "@remix-run/node";
+
+import { POST, PUT, requireUser } from "shared/api";
+import { parseAsArticle } from "../model/parseAsArticle";
+
+export const action = async ({ request, params }: ActionFunctionArgs) => {
+  try {
+    const { body, description, title, tags } = parseAsArticle(
+      await request.formData(),
+    );
+    const tagList = tags?.split(",") ?? [];
+
+    const currentUser = await requireUser(request);
+    const payload = {
+      body: {
+        article: {
+          title,
+          description,
+          body,
+          tagList,
+        },
+      },
+      headers: { Authorization: `Token ${currentUser.token}` },
+    };
+
+    const { data, error } = await (params.slug
+      ? PUT("/articles/{slug}", {
+          params: { path: { slug: params.slug } },
+          ...payload,
+        })
+      : POST("/articles", payload));
+
+    if (error) {
+      return json({ errors: error }, { status: 422 });
+    }
+
+    return redirect(`/article/${data.article.slug ?? ""}`);
+  } catch (errors) {
+    return json({ errors }, { status: 400 });
+  }
+};
+```
+
+Schema có vai trò kép như một function phân tích cho `FormData`, cho phép chúng ta thuận tiện lấy các trường sạch hoặc chỉ throw lỗi để xử lý ở cuối. Đây là cách function phân tích đó có thể trông như thế nào:
+
+```tsx title="pages/article-edit/model/parseAsArticle.ts"
+export function parseAsArticle(data: FormData) {
+  const errors = [];
+
+  const title = data.get("title");
+  if (typeof title !== "string" || title === "") {
+    errors.push("Give this article a title");
+  }
+
+  const description = data.get("description");
+  if (typeof description !== "string" || description === "") {
+    errors.push("Describe what this article is about");
+  }
+
+  const body = data.get("body");
+  if (typeof body !== "string" || body === "") {
+    errors.push("Write the article itself");
+  }
+
+  const tags = data.get("tags");
+  if (typeof tags !== "string") {
+    errors.push("The tags must be a string");
+  }
+
+  if (errors.length > 0) {
+    throw errors;
+  }
+
+  return { title, description, body, tags: data.get("tags") ?? "" } as {
+    title: string;
+    description: string;
+    body: string;
+    tags: string;
+  };
+}
+```
+
+Có thể nói, nó hơi dài và lặp lại, nhưng đó là cái giá chúng ta phải trả cho các lỗi có thể đọc được. Điều này cũng có thể là Zod schema, ví dụ, nhưng sau đó chúng ta sẽ phải render thông báo lỗi trên frontend, và form này không đáng để phức tạp hóa.
+
+Một bước cuối cùng — kết nối trang, loader, và action với các route. Vì chúng ta hỗ trợ gọn gàng cả tạo và chỉnh sửa, chúng ta có thể export cùng một thứ từ cả `editor._index.tsx` và `editor.$slug.tsx`:
+
+```tsx title="pages/article-edit/index.ts"
+export { ArticleEditPage } from "./ui/ArticleEditPage";
+export { loader } from "./api/loader";
+export { action } from "./api/action";
+```
+
+```tsx title="app/routes/editor._index.tsx, app/routes/editor.$slug.tsx (same content)"
+import { ArticleEditPage } from "pages/article-edit";
+
+export { loader, action } from "pages/article-edit";
+
+export default ArticleEditPage;
+```
+
+Chúng ta hoàn thành rồi! Đăng nhập và thử tạo article mới. Hoặc "quên" viết article và xem validation hoạt động.
+
+<figure>
+  ![The Conduit article editor, with the title field saying "New article" and the rest of the fields empty. Above the form there are two errors: "**Describe what this article is about" and "Write the article itself".**](/img/tutorial/realworld-article-editor.jpg)
+
+  <figcaption>Trình chỉnh sửa article Conduit, với trường tiêu đề nói "New article" và phần còn lại của các trường trống. Phía trên form có hai lỗi: **"Describe what this article is about"** và **"Write the article itself"**.</figcaption>
+</figure>
+
+Các trang profile và settings rất giống với trình đọc và chỉnh sửa article, chúng được để lại như bài tập cho người đọc, đó là bạn :)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/_category_.yaml
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/_category_.yaml
@@ -1,0 +1,2 @@
+label: Ví dụ
+position: 1

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/api-requests.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/api-requests.mdx
@@ -1,0 +1,141 @@
+---
+sidebar_position: 4
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Xử lý API Requests {#handling-api-requests}
+
+## Shared API Requests {#shared-api-requests}
+
+Bắt đầu bằng cách đặt logic API request chung trong thư mục `shared/api`. Điều này giúp dễ dàng tái sử dụng các request trong toàn bộ ứng dụng và hỗ trợ prototyping nhanh hơn. Đối với nhiều dự án, đây là tất cả những gì bạn cần cho các API call.
+
+Cấu trúc file điển hình sẽ là:
+- 📂 shared
+    - 📂 api
+        - 📄 client.ts
+        - 📄 index.ts
+        - 📂 endpoints
+            - 📄 login.ts
+
+File `client.ts` tập trung thiết lập HTTP request của bạn. Nó bao bọc phương thức bạn chọn (như `fetch()` hoặc một instance `axios`) và xử lý các cấu hình chung, chẳng hạn như:
+
+- Backend base URL.
+- Default headers (ví dụ, cho authentication).
+- Data serialization.
+
+Dưới đây là các ví dụ cho `axios` và `fetch`:
+
+<Tabs>
+
+<TabItem value="axios" label="Axios">
+```ts title="shared/api/client.ts"
+// Example using axios
+import axios from 'axios';
+
+export const client = axios.create({
+  baseURL: 'https://your-api-domain.com/api/',
+  timeout: 5000,
+  headers: { 'X-Custom-Header': 'my-custom-value' }
+});
+```
+</TabItem>
+
+<TabItem value="fetch" label="Fetch">
+```ts title="shared/api/client.ts"
+export const client = {
+  async post(endpoint: string, body: any, options?: RequestInit) {
+    const response = await fetch(`https://your-api-domain.com/api${endpoint}`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom-Header': 'my-custom-value',
+        ...options?.headers,
+      },
+    });
+    return response.json();
+  }
+  // ... other methods like put, delete, etc.
+};
+```
+</TabItem>
+
+</Tabs>
+
+Tổ chức các function API request riêng lẻ của bạn trong `shared/api/endpoints`, nhóm chúng theo API endpoint.
+
+:::note
+
+Để giữ các ví dụ tập trung, chúng tôi bỏ qua form interaction và validation. Để biết chi tiết về các thư viện như Zod hoặc Valibot, hãy tham khảo bài viết [Type Validation và Schemas](/docs/guides/examples/types#type-validation-schemas-and-zod).
+
+:::
+
+```ts title="shared/api/endpoints/login.ts"
+import { client } from '../client';
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export function login(credentials: LoginCredentials) {
+  return client.post('/login', credentials);
+}
+```
+Sử dụng file `index.ts` trong `shared/api` để export các function request của bạn.
+
+```ts title="shared/api/index.ts"
+export { client } from './client'; // Nếu bạn muốn export client
+export { login } from './endpoints/login';
+export type { LoginCredentials } from './endpoints/login';
+```
+
+## Slice-Specific API Requests {#slice-specific-api-requests}
+
+Nếu một API request chỉ được sử dụng bởi một slice cụ thể (như một page hoặc feature đơn lẻ) và sẽ không được tái sử dụng, hãy đặt nó trong segment api của slice đó. Điều này giúp logic slice-specific được chứa đóng một cách gọn gàng.
+
+- 📂 pages
+    - 📂 login
+        - 📄 index.ts
+        - 📂 api
+            - 📄 login.ts
+        - 📂 ui
+            - 📄 LoginPage.tsx
+
+```ts title="pages/login/api/login.ts"
+import { client } from 'shared/api';
+
+interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export function login(credentials: LoginCredentials) {
+  return client.post('/login', credentials);
+}
+```
+
+Bạn không cần export function `login()` trong public API của page, vì không có khả năng nơi nào khác trong app sẽ cần request này.
+
+:::note
+
+Tránh đặt API calls và response types trong layer `entities` quá sớm. Backend responses có thể khác với những gì frontend entities của bạn cần. Logic API trong `shared/api` hoặc segment `api` của slice cho phép bạn transform data một cách phù hợp, giữ cho entities tập trung vào các mối quan tâm của frontend.
+
+:::
+
+## Sử dụng Client Generators {#client-generators}
+
+Nếu backend của bạn có OpenAPI specification, các công cụ như [orval](https://orval.dev/) hoặc [openapi-typescript](https://openapi-ts.dev/) có thể generate API types và request functions cho bạn. Đặt code được generate trong, ví dụ, `shared/api/openapi`. Đảm bảo bao gồm `README.md` để document những types đó là gì và cách generate chúng.
+
+## Tích hợp với Server State Libraries {#server-state-libraries}
+
+Khi sử dụng server state libraries như [TanStack Query (React Query)](https://tanstack.com/query/latest) hoặc [Pinia Colada](https://pinia-colada.esm.dev/), bạn có thể cần chia sẻ types hoặc cache keys giữa các slices. Sử dụng layer `shared` cho những thứ như:
+
+- API data types
+- Cache keys
+- Common query/mutation options
+
+Để biết thêm chi tiết về cách làm việc với server state libraries, hãy tham khảo [bài viết React Query](/docs/guides/tech/with-react-query) 

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/auth.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/auth.md
@@ -1,0 +1,173 @@
+---
+sidebar_position: 1
+---
+
+# Authentication
+
+Nói chung, authentication bao gồm các bước sau:
+
+1. Lấy credentials từ người dùng
+1. Gửi chúng đến backend
+1. Lưu trữ token để thực hiện các authenticated requests
+
+## Cách lấy credentials từ người dùng
+
+Chúng tôi giả định rằng app của bạn chịu trách nhiệm lấy credentials. Nếu bạn có authentication qua OAuth, bạn có thể đơn giản tạo một login page với link đến login page của OAuth provider và bỏ qua đến [bước 3](#how-to-store-the-token-for-authenticated-requests).
+
+### Page chuyên dụng cho login
+
+Thông thường, các websites có các pages chuyên dụng cho login, nơi bạn nhập username và password. Các pages này khá đơn giản, vì vậy chúng không yêu cầu decomposition. Login và registration forms khá giống nhau về ngoại hình, vì vậy chúng thậm chí có thể được nhóm vào một page. Tạo một slice cho login/registration page của bạn trên layer Pages:
+
+- 📂 pages
+    - 📂 login
+        - 📂 ui
+            - 📄 LoginPage.tsx (or your framework's component file format)
+            - 📄 RegisterPage.tsx
+        - 📄 index.ts
+    - other pages…
+
+Ở đây chúng tôi tạo hai components và export cả hai trong index file của slice. Các components này sẽ chứa forms chịu trách nhiệm trình bày cho người dùng các controls dễ hiểu để lấy credentials của họ.
+
+### Dialog cho login
+
+Nếu app của bạn có dialog cho login có thể được sử dụng trên bất kỳ page nào, hãy cân nhắc tạo dialog đó thành một widget. Bằng cách đó, bạn vẫn có thể tránh quá nhiều decomposition, nhưng có tự do tái sử dụng dialog này trên bất kỳ page nào.
+
+- 📂 widgets
+    - 📂 login-dialog
+        - 📂 ui
+            - 📄 LoginDialog.tsx
+        - 📄 index.ts
+    - other widgets…
+
+Phần còn lại của hướng dẫn này được viết cho cách tiếp cận dedicated page, nhưng các nguyên tắc tương tự áp dụng cho dialog widget.
+
+### Client-side validation
+
+Thiệng thoảng, đặc biệt là cho registration, việc thực hiện client-side validation để cho người dùng biết nhanh chóng rằng họ đã mắc lỗi là hợp lý. Validation có thể diễn ra trong segment `model` của login page. Sử dụng một schema validation library, ví dụ, [Zod][ext-zod] cho JS/TS, và expose schema đó cho segment `ui`:
+
+```ts title="pages/login/model/registration-schema.ts"
+import { z } from "zod";
+
+export const registrationData = z.object({
+    email: z.string().email(),
+    password: z.string().min(6),
+    confirmPassword: z.string(),
+}).refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+});
+```
+    
+Sau đó, trong segment `ui`, bạn có thể sử dụng schema này để validate user input:
+
+```tsx title="pages/login/ui/RegisterPage.tsx"
+import { registrationData } from "../model/registration-schema";
+
+function validate(formData: FormData) {
+    const data = Object.fromEntries(formData.entries());
+    try {
+        registrationData.parse(data);
+    } catch (error) {
+        // TODO: Show error message to the user
+    }
+}
+
+export function RegisterPage() {
+    return (
+        <form onSubmit={(e) => validate(new FormData(e.target))}>
+            <label htmlFor="email">E-mail</label>
+            <input id="email" name="email" required />
+
+            <label htmlFor="password">Password (min. 6 characters)</label>
+            <input id="password" name="password" type="password" required />
+
+            <label htmlFor="confirmPassword">Confirm password</label>
+            <input id="confirmPassword" name="confirmPassword" type="password" required />
+        </form>
+    )
+}
+```
+
+## Cách gửi credentials đến backend
+
+Tạo một function thực hiện request đến login endpoint của backend. Function này có thể được gọi trực tiếp trong component code sử dụng mutation library (ví dụ TanStack Query), hoặc có thể được gọi như side effect trong state manager. Như được giải thích trong [hướng dẫn cho API requests][examples-api-requests], bạn có thể đặt request của mình trong `shared/api` hoặc trong segment `api` của login page.
+
+### Two-factor authentication
+
+Nếu app của bạn hỗ trợ two-factor authentication (2FA), bạn có thể phải redirect đến page khác nơi người dùng có thể nhập one-time password. Thông thường `POST /login` request của bạn sẽ trả về user object với flag chỉ ra rằng người dùng đã bật 2FA. Nếu flag đó được thiết lập, redirect người dùng đến 2FA page.
+
+Vì page này liên quan rất chặt chẽ đến logging in, bạn cũng có thể giữ nó trong cùng một slice, `login` trên layer Pages.
+
+Bạn cũng cần một request function khác, tương tự như `login()` mà chúng tôi đã tạo ở trên. Đặt chúng cùng nhau, hoặc trong Shared, hoặc trong segment `api` của page `login`.
+
+## Cách lưu trữ token cho authenticated requests {#how-to-store-the-token-for-authenticated-requests}
+
+Bất kể authentication scheme nào bạn có, cho dù là login & password đơn giản, OAuth, hoặc two-factor authentication, cuối cùng bạn sẽ nhận được một token. Token này nên được lưu trữ để các requests tiếp theo có thể identify chính chúng.
+
+Lưu trữ token lý tưởng cho web app là **cookie** — nó không yêu cầu token storage hoặc handling thủ công. Vì vậy, cookie storage hầu như không cần cân nhắc gì từ phía frontend architecture. Nếu frontend framework của bạn có server side (ví dụ, [Remix][ext-remix]), thì bạn nên lưu trữ server-side cookie infrastructure trong `shared/api`. Có một ví dụ trong [phần Authentication của tutorial][tutorial-authentication] về cách thực hiện điều đó với Remix.
+
+Tuy nhiên, đôi khi cookie storage không phải là lựa chọn. Trong trường hợp này, bạn sẽ phải lưu trữ token thủ công. Ngoài việc lưu trữ token, bạn cũng có thể cần thiết lập logic để refresh token khi nó expires. Với FSD, có nhiều nơi bạn có thể lưu trữ token, cũng như nhiều cách để làm cho nó available cho phần còn lại của app.
+
+### Trong Shared
+
+Cách tiếp cận này hoạt động tốt với API client được define trong `shared/api` vì token có sẵn một cách tự do cho các request functions khác yêu cầu authentication để thành công. Bạn có thể làm cho API client giữ state, hoặc với reactive store hoặc đơn giản là module-level variable, và cập nhật state đó trong các functions `login()`/`logout()` của bạn.
+
+Automatic token refresh có thể được implement như middleware trong API client — thứ gì đó có thể thực thi mỗi khi bạn thực hiện bất kỳ request nào. Nó có thể hoạt động như thế này:
+
+- Authenticate và lưu trữ access token cũng như refresh token
+- Thực hiện bất kỳ request nào yêu cầu authentication
+- Nếu request thất bại với status code chỉ ra token expiration, và có token trong store, thực hiện refresh request, lưu trữ các tokens mới, và retry request gốc
+
+Một trong những drawbacks của cách tiếp cận này là logic managing và refreshing token không có một nơi chuyên dụng. Điều này có thể ổn đối với một số apps hoặc teams, nhưng nếu logic token management phức tạp hơn, có thể tốt hơn là tách biệt trách nhiệm của việc thực hiện requests và managing tokens. Bạn có thể làm điều đó bằng cách giữ requests và API client trong `shared/api`, nhưng token store và management logic trong `shared/auth`.
+
+Một drawback khác của cách tiếp cận này là nếu backend của bạn trả về object thông tin của current user cùng với token, bạn phải lưu trữ điều đó ở đâu đó hoặc bỏ qua thông tin đó và request lại từ endpoint như `/me` hoặc `/users/current`.
+
+### Trong Entities
+
+Thông thường các dự án FSD có một entity cho user và/hoặc một entity cho current user. Nó thậm chí có thể là cùng một entity cho cả hai.
+
+:::note
+
+**Current user** đôi khi cũng được gọi là "viewer" hoặc "me". Điều này là để phân biệt single authenticated user, với permissions và private information, từ danh sách tất cả users với publicly accessible information.
+
+:::
+
+Để lưu trữ token trong User entity, tạo reactive store trong segment `model`. Store đó có thể chứa cả token và user object.
+
+Vì API client thường được define trong `shared/api` hoặc spread qua các entities, thách thức chính của cách tiếp cận này là làm cho token available cho các requests khác cần nó mà không vi phạm [import rule trên các layers][import-rule-on-layers]:
+
+> Một module (file) trong slice chỉ có thể import các slices khác khi chúng được đặt trên các layers ở phía dưới.
+
+Có nhiều giải pháp cho thách thức này:
+
+1. **Pass token thủ công mỗi lần bạn thực hiện request**  
+    Đây là giải pháp đơn giản nhất, nhưng nó nhanh chóng trở nên cồng kềnh, và nếu bạn không có type safety, dễ quên. Nó cũng không tương thích với middlewares pattern cho API client trong Shared.
+1. **Expose token cho toàn bộ app với context hoặc global store như `localStorage`**  
+    Key để retrieve token sẽ được giữ trong `shared/api` để API client có thể truy cập nó. Reactive store của token sẽ được export từ User entity, và context provider (nếu cần) sẽ được thiết lập trên layer App. Điều này cho nhiều tự do hơn để thiết kế API client, tuy nhiên, nó tạo ra implicit dependency trên các layers cao hơn để cung cấp context. Khi theo cách tiếp cận này, hãy cân nhắc cung cấp các error messages hữu ích nếu context hoặc `localStorage` không được thiết lập chính xác.
+1. **Inject token vào API client mỗi khi nó thay đổi**  
+    Nếu store của bạn là reactive, bạn có thể tạo subscription sẽ cập nhật token store của API client mỗi khi store trong entity thay đổi. Điều này tương tự như giải pháp trước ở chỗ chúng đều tạo implicit dependency trên các layers cao hơn, nhưng cái này imperative hơn ("push"), trong khi cái trước declarative hơn ("pull").
+
+Khi bạn vượt qua thách thức expose token được lưu trữ trong model của entity, bạn có thể encode nhiều business logic liên quan đến token management. Ví dụ, segment `model` có thể chứa logic để invalidate token sau một khoảng thời gian nhất định, hoặc refresh token khi nó expires. Để thực sự thực hiện requests đến backend, sử dụng segment `api` của User entity hoặc `shared/api`.
+
+### Trong Pages/Widgets (không được khuyến nghị)
+
+Không được khuyến khích lưu trữ app-wide state như access token trong pages hoặc widgets. Tránh đặt token store của bạn trong segment `model` của login page, thay vào đó hãy chọn từ hai giải pháp đầu tiên, Shared hoặc Entities.
+
+## Logout và token invalidation
+
+Thông thường, các apps không có một page hoàn chỉnh cho logging out, nhưng logout functionality vẫn rất quan trọng. Nó bao gồm authenticated request đến backend và cập nhật token store.
+
+Nếu bạn lưu trữ tất cả requests trong `shared/api`, hãy giữ logout request function ở đó, gần login function. Nếu không, hãy cân nhắc giữ logout request function gần button kích hoạt nó. Ví dụ, nếu bạn có header widget xuất hiện trên mỗi page và chứa logout link, hãy đặt request đó trong segment `api` của widget đó.
+
+Cập nhật token store sẽ phải được trigger từ vị trí của logout button, như header widget. Bạn có thể kết hợp request và store update trong segment `model` của widget đó.
+
+### Automatic logout
+
+Đừng quên xây dựng các failsafes cho khi request log out thất bại, hoặc request refresh login token thất bại. Trong cả hai trường hợp này, bạn nên clear token store. Nếu bạn giữ token trong Entities, code này có thể được đặt trong segment `model` vì nó là pure business logic. Nếu bạn giữ token trong Shared, đặt logic này trong `shared/api` có thể làm segment phình to và pha loãng mục đích của nó. Nếu bạn nhận thấy rằng API segment của mình chứa nhiều thứ không liên quan, hãy cân nhắc tách logic token management thành segment khác, ví dụ, `shared/auth`.
+
+[tutorial-authentication]: /docs/get-started/tutorial#authentication
+[import-rule-on-layers]: /docs/reference/layers#import-rule-on-layers
+[examples-api-requests]: /docs/guides/examples/api-requests
+[ext-remix]: https://remix.run
+[ext-zod]: https://zod.dev
+

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/autocompleted.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/autocompleted.mdx
@@ -1,0 +1,18 @@
+---
+sidebar_position: 5
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Autocomplete
+
+<!-- Such a route, because docusaurus crashes with" autocomplete " for some reason: / -->
+
+<WIP ticket="170" />
+
+> Về decomposition theo layers
+
+## Xem thêm
+- [(Discussion) Về việc áp dụng phương pháp luận cho việc lựa chọn với loaded dictionaries](https://github.com/feature-sliced/documentation/discussions/65#discussioncomment-480807)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/browser-api.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/browser-api.mdx
@@ -1,0 +1,14 @@
+---
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Browser API
+
+<WIP ticket="197" />
+
+> Về việc làm việc với Browser API: localStorage, audio Api, bluetooth API, v.v.
+>
+> Bạn có thể hỏi về ý tưởng chi tiết hơn [@alex_novi](https://t.me/alex_novich)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/cms.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/cms.mdx
@@ -1,0 +1,22 @@
+---
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# CMS
+
+<WIP ticket="172" />
+
+## Features có thể khác nhau
+
+Trong một số dự án, tất cả functionality được tập trung trong data từ server
+
+> https://github.com/feature-sliced/documentation/discussions/65#discussioncomment-480785
+
+## Cách làm việc đúng đắn hơn với CMS markup
+
+> https://t.me/feature_sliced/1557
+
+> https://t.me/feature_sliced/1553

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/feedback.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/feedback.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Feedback
+
+<WIP ticket="187" />
+
+> Errors, Alerts, Notifications, ...

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/i18n.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/i18n.mdx
@@ -1,0 +1,17 @@
+---
+sidebar_position: 6
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# i18n
+
+<WIP ticket="171" />
+
+## Đặt ở đâu? Làm thế nào để làm việc với điều này?
+
+- https://t.me/feature_sliced/4425
+- https://t.me/feature_sliced/2325
+- https://t.me/feature_sliced/1867

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/metric.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/metric.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Metric
+
+<WIP ticket="181" />
+
+> About ways to initialize metrics in the application

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/monorepo.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/monorepo.mdx
@@ -1,0 +1,18 @@
+---
+sidebar_position: 9
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Monorepositories
+
+<WIP ticket="221" />
+
+> About applicability for mono repositories, about bff, about microapps
+
+## See also
+
+- [(Discussion) About mono repositories and plug-ins-packages](https://github.com/feature-sliced/documentation/discussions/50)
+- [(Thread) About the application for a mono repository](https://t.me/feature_sliced/2412)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/page-layout.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/page-layout.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 3
+---
+
+# Page layouts
+
+Hướng dẫn này xem xét abstraction của một _page layout_ — khi nhiều pages chia sẻ cùng một cấu trúc tổng thể, và chỉ khác nhau ở main content.
+
+:::info
+
+Câu hỏi của bạn không được đề cập trong hướng dẫn này? Đăng câu hỏi của bạn bằng cách để lại feedback trên bài viết này (nút xanh ở bên phải) và chúng tôi sẽ cân nhắc mở rộng hướng dẫn này!
+
+:::
+
+## Simple layout
+
+Layout đơn giản nhất có thể được nhìn thấy trên trang bạn đang xem đây. Nó có header với site navigation, hai sidebars, và footer với external links. Không có business logic phức tạp, và các phần dynamic duy nhất là sidebars và switchers ở phía bên phải của header. Layout như vậy có thể được đặt hoàn toàn trong `shared/ui` hoặc trong `app/layouts`, với props điền vào content cho các sidebars:
+
+```tsx title="shared/ui/layout/Layout.tsx"
+import { Link, Outlet } from "react-router-dom";
+import { useThemeSwitcher } from "./useThemeSwitcher";
+
+export function Layout({ siblingPages, headings }) {
+  const [theme, toggleTheme] = useThemeSwitcher();
+
+  return (
+    <div>
+      <header>
+        <nav>
+          <ul>
+            <li> <Link to="/">Home</Link> </li>
+            <li> <Link to="/docs">Docs</Link> </li>
+            <li> <Link to="/blog">Blog</Link> </li>
+          </ul>
+        </nav>
+        <button onClick={toggleTheme}>{theme}</button>
+      </header>
+      <main>
+        <SiblingPageSidebar siblingPages={siblingPages} />
+        <Outlet /> {/* This is where the main content goes */}
+        <HeadingsSidebar headings={headings} />
+      </main>
+      <footer>
+        <ul>
+          <li>GitHub</li>
+          <li>Twitter</li>
+        </ul>
+      </footer>
+    </div>
+  );
+}
+```
+
+```ts title="shared/ui/layout/useThemeSwitcher.ts"
+export function useThemeSwitcher() {
+  const [theme, setTheme] = useState("light");
+
+  function toggleTheme() {
+    setTheme(theme === "light" ? "dark" : "light");
+  }
+
+  useEffect(() => {
+    document.body.classList.remove("light", "dark");
+    document.body.classList.add(theme);
+  }, [theme]);
+
+  return [theme, toggleTheme] as const;
+}
+```
+
+Code của các sidebars được để lại như bài tập cho độc giả 😉.
+
+## Sử dụng widgets trong layout
+
+Thiệng thoảng bạn muốn bao gồm business logic nhất định trong layout, đặc biệt nếu bạn đang sử dụng deeply nested routes với router như [React Router][ext-react-router]. Khi đó bạn không thể lưu trữ layout trong Shared hoặc trong Widgets do [import rule trên các layers][import-rule-on-layers]:
+
+> Một module trong slice chỉ có thể import các slices khác khi chúng được đặt trên các layers ở phía dưới.
+
+Trước khi chúng ta thảo luận các giải pháp, chúng ta cần thảo luận liệu đó có phải là vấn đề ngay từ đầu hay không. Bạn có _thực sự cần_ layout đó không, và nếu có, liệu nó _thực sự cần_ là Widget không? Nếu block business logic đang bàn được tái sử dụng trên 2-3 pages, và layout chỉ đơn giản là wrapper nhỏ cho widget đó, hãy cân nhắc một trong hai lựa chọn này:
+
+1. **Viết layout inline trên layer App, nơi bạn cấu hình routing**  
+   Điều này rất tốt cho các routers hỗ trợ nesting, vì bạn có thể nhóm các routes nhất định và chỉ áp dụng layout cho chúng.
+
+2. **Chỉ cần copy-paste nó**  
+   Xu hướng abstract code thường bị đánh giá quá cao. Điều này đặc biệt đúng cho các layouts, hiếm khi thay đổi. Tại một thời điểm nào đó, nếu một trong những pages này cần thay đổi, bạn có thể đơn giản thực hiện thay đổi mà không cần thiết ảnh hưởng đến các pages khác. Nếu bạn lo lắng rằng ai đó có thể quên cập nhật các pages khác, bạn luôn có thể để lại comment mô tả mối quan hệ giữa các pages.
+
+Nếu không có điều nào ở trên áp dụng được, có hai giải pháp để bao gồm widget trong layout:
+
+1. **Sử dụng render props hoặc slots**  
+   Hầu hết các frameworks cho phép bạn pass một phần UI từ bên ngoài. Trong React, được gọi là [render props][ext-render-props], trong Vue được gọi là [slots][ext-vue-slots].
+2. **Chuyển layout đến layer App**  
+   Bạn cũng có thể lưu trữ layout của mình trên layer App, ví dụ, trong `app/layouts`, và compose bất kỳ widgets nào bạn muốn.
+
+## Đọc thêm
+
+- Có một ví dụ về cách xây dựng layout với authentication sử dụng React và Remix (tương đương với React Router) trong [tutorial][tutorial].
+
+[tutorial]: /docs/get-started/tutorial
+[import-rule-on-layers]: /docs/reference/layers#import-rule-on-layers
+[ext-react-router]: https://reactrouter.com/
+[ext-render-props]: https://www.patterns.dev/react/render-props-pattern/
+[ext-vue-slots]: https://vuejs.org/guide/components/slots

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/platforms.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/platforms.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Desktop/Touch platforms
+
+<WIP ticket="198" />
+
+> About the application of the methodology for desktop/touch

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/ssr.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/ssr.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# SSR
+
+<WIP ticket="173" />
+
+> About the implementation of SSR using the methodology

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/theme.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/theme.mdx
@@ -1,0 +1,19 @@
+---
+sidebar_position: 4
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Theme
+
+<WIP ticket="207" />
+
+## Where should I put my work with the theme and palette?
+
+> https://t.me/feature_sliced/4410
+
+## Discussion about the location of the theme, i18n logic
+
+> https://youtu.be/b_nBvHWqxP8?t=133

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/types.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/types.md
@@ -1,0 +1,440 @@
+---
+sidebar_position: 2
+---
+
+# Types
+
+Hướng dẫn này liên quan đến data types từ các typed languages như TypeScript và mô tả chúng phù hợp ở đâu trong FSD.
+
+:::info
+
+Câu hỏi của bạn không được đề cập trong hướng dẫn này? Đăng câu hỏi của bạn bằng cách để lại feedback trên bài viết này (nút xanh ở bên phải) và chúng tôi sẽ cân nhắc mở rộng hướng dẫn này!
+
+:::
+
+## Utility types
+
+Utility types là các types không có nhiều ý nghĩa riêng và thường được sử dụng với các types khác. Ví dụ:
+
+<figure>
+
+```ts
+type ArrayValues<T extends readonly unknown[]> = T[number];
+```
+
+<figcaption>
+  Nguồn: https://github.com/sindresorhus/type-fest/blob/main/source/array-values.d.ts
+</figcaption>
+
+</figure>
+
+Để làm cho utility types có sẵn trong toàn bộ dự án của bạn, hoặc là install một library như [`type-fest`][ext-type-fest], hoặc tạo library riêng của bạn trong `shared/lib`. Đảm bảo chỉ rõ ràng những types mới nào _nên_ được thêm vào library này, và những types nào _không thuộc về_ đó. Ví dụ, gọi nó là `shared/lib/utility-types` và thêm README bên trong mô tả utility type là gì trong team của bạn.
+
+Đừng đánh giá quá cao khả năng tái sử dụng của utility type. Chỉ vì nó có thể được tái sử dụng, không có nghĩa là nó sẽ được tái sử dụng, và vì vậy, không phải mọi utility type đều cần ở trong Shared. Một số utility types thì ổn ngay bên cạnh nơi chúng được cần:
+
+- 📂 pages
+  - 📂 home
+    - 📂 api
+      - 📄 ArrayValues.ts (utility type)
+      - 📄 getMemoryUsageMetrics.ts (code sử dụng utility type)
+
+:::warning
+
+Hãy cưỡng lại cám dỗ tạo folder `shared/types`, hoặc thêm segment `types` vào slices của bạn. Category "types" tương tự như category "components" hoặc "hooks" ở chỗ nó mô tả nội dung là gì, chứ không phải chúng dành cho gì. Segments nên mô tả mục đích của code, không phải bản chất.
+
+:::
+
+## Business entities và cross-references của chúng
+
+Trong số những types quan trọng nhất trong app là types của business entities, tức là những thứ trong thế giới thực mà app của bạn làm việc với. Ví dụ, trong music streaming app, bạn có thể có business entities _Song_, _Album_, v.v.
+
+Business entities thường đến từ backend, vì vậy bước đầu tiên là type backend responses. Thật tiện lợi khi có function để thực hiện request đến mỗi endpoint, và type response của function này. Để có thêm type safety, bạn có thể muốn chạy response qua schema validation library như [Zod][ext-zod]. 
+
+Ví dụ, nếu bạn giữ tất cả requests của mình trong Shared, bạn có thể làm như thế này:
+
+```ts title="shared/api/songs.ts"
+import type { Artist } from "./artists";
+
+interface Song {
+  id: number;
+  title: string;
+  artists: Array<Artist>;
+}
+
+export function listSongs() {
+  return fetch('/api/songs').then((res) => res.json() as Promise<Array<Song>>);
+}
+```
+
+Bạn có thể nhận thấy rằng type `Song` tham chiếu đến một entity khác, `Artist`. Đây là lợi ích của việc lưu trữ requests của bạn trong Shared — các types thế giới thực thường đan xen. Nếu chúng ta giữ function này trong `entities/song/api`, chúng ta sẽ không thể đơn giản import `Artist` từ `entities/artist`, vì FSD hạn chế cross-imports giữa các slices với [import rule trên các layers][import-rule-on-layers]:
+
+> Một module trong slice chỉ có thể import các slices khác khi chúng được đặt trên các layers ở phía dưới.
+
+Có hai cách để giải quyết vấn đề này:
+
+1. **Tham số hóa các types của bạn**  
+   Bạn có thể làm cho types của mình chấp nhận type arguments làm slots cho các kết nối với entities khác, và thậm chí áp dụng constraints trên những slots đó. Ví dụ:
+
+   ```ts title="entities/song/model/song.ts"
+   interface Song<ArtistType extends { id: string }> {
+     id: number;
+     title: string;
+     artists: Array<ArtistType>;
+   }
+   ```
+
+   Điều này hoạt động tốt hơn cho một số types so với những types khác. Một type đơn giản như `Cart = { items: Array<Product> }` có thể dễ dàng được làm để hoạt động với bất kỳ loại product nào. Các types kết nối nhiều hơn, như `Country` và `City`, có thể không dễ tách rời.
+
+2. **Cross-import (nhưng làm đúng cách)**  
+   Để thực hiện cross-imports giữa các entities trong FSD, bạn có thể sử dụng public API đặc biệt dành riêng cho mỗi slice sẽ cross-importing. Ví dụ, nếu chúng ta có entities `song`, `artist`, và `playlist`, và hai cái sau cần tham chiếu `song`, chúng ta có thể tạo hai public APIs đặc biệt cho cả hai trong entity `song` với ký hiệu `@x`:
+
+   - 📂 entities
+     - 📂 song
+       - 📂 @x
+         - 📄 artist.ts (public API cho entity `artist` để import)
+         - 📄 playlist.ts (public API cho entity `playlist` để import)
+       - 📄 index.ts (public API thông thường)
+   
+   Nội dung của file `📄 entities/song/@x/artist.ts` tương tự như `📄 entities/song/index.ts`:
+
+   ```ts title="entities/song/@x/artist.ts"
+   export type { Song } from "../model/song.ts";
+   ```
+
+   Sau đó `📄 entities/artist/model/artist.ts` có thể import `Song` như thế này:
+
+   ```ts title="entities/artist/model/artist.ts"
+   import type { Song } from "entities/song/@x/artist";
+
+   export interface Artist {
+     name: string;
+     songs: Array<Song>;
+   }
+   ```
+
+   Bằng cách tạo kết nối rõ ràng giữa các entities, chúng ta kiểm soát được inter-dependencies và duy trì mức độ phân tách domain tốt.
+
+## Data transfer objects và mappers {#data-transfer-objects-and-mappers}
+
+Data transfer objects, hay DTOs, là thuật ngữ mô tả hình dạng của dữ liệu đến từ backend. Đôi khi, DTO có thể sử dụng ngay, nhưng đôi khi nó không thuận tiện cho frontend. Đó là lúc mappers xuất hiện — chúng biến đổi DTO thành hình dạng thuận tiện hơn.
+
+### Đặt DTOs ở đâu
+
+Nếu bạn có backend types trong package riêng (ví dụ, nếu bạn chia sẻ code giữa frontend và backend), thì chỉ cần import DTOs từ đó và xong! Nếu bạn không chia sẻ code giữa backend và frontend, thì bạn cần giữ DTOs ở đâu đó trong frontend codebase, và chúng ta sẽ khám phá trường hợp này dưới đây.
+
+Nếu bạn có request functions trong `shared/api`, đó là nơi DTOs nên ở, ngay cạnh function sử dụng chúng:
+
+```ts title="shared/api/songs.ts"
+import type { ArtistDTO } from "./artists";
+
+interface SongDTO {
+  id: number;
+  title: string;
+  artist_ids: Array<ArtistDTO["id"]>;
+}
+
+export function listSongs() {
+  return fetch('/api/songs').then((res) => res.json() as Promise<Array<SongDTO>>);
+}
+```
+
+Như đã đề cập trong phần trước, lưu trữ requests và DTOs của bạn trong Shared mang lại lợi ích có thể tham chiếu DTOs khác.
+
+### Đặt mappers ở đâu
+
+Mappers là các functions chấp nhận DTO để biến đổi, và vì vậy, chúng nên được đặt gần định nghĩa của DTO. Trong thực tế điều này có nghĩa là nếu requests và DTOs của bạn được định nghĩa trong `shared/api`, thì mappers cũng nên ở đó:
+
+```ts title="shared/api/songs.ts"
+import type { ArtistDTO } from "./artists";
+
+interface SongDTO {
+  id: number;
+  title: string;
+  disc_no: number;
+  artist_ids: Array<ArtistDTO["id"]>;
+}
+
+interface Song {
+  id: string;
+  title: string;
+  /** Tiêu đề đầy đủ của bài hát, bao gồm số đĩa. */
+  fullTitle: string;
+  artistIds: Array<string>;
+}
+
+function adaptSongDTO(dto: SongDTO): Song {
+  return {
+    id: String(dto.id),
+    title: dto.title,
+    fullTitle: `${dto.disc_no} / ${dto.title}`,
+    artistIds: dto.artist_ids.map(String),
+  };
+}
+
+export function listSongs() {
+  return fetch('/api/songs').then(async (res) => (await res.json()).map(adaptSongDTO));
+}
+```
+
+Nếu requests và stores của bạn được định nghĩa trong entity slices, thì tất cả code này sẽ đi vào đó, nhớ lưu ý giới hạn của cross-imports giữa các slices:
+
+```ts title="entities/song/api/dto.ts"
+import type { ArtistDTO } from "entities/artist/@x/song";
+
+export interface SongDTO {
+  id: number;
+  title: string;
+  disc_no: number;
+  artist_ids: Array<ArtistDTO["id"]>;
+}
+```
+
+```ts title="entities/song/api/mapper.ts"
+import type { SongDTO } from "./dto";
+
+export interface Song {
+  id: string;
+  title: string;
+  /** Tiêu đề đầy đủ của bài hát, bao gồm số đĩa. */
+  fullTitle: string;
+  artistIds: Array<string>;
+}
+
+export function adaptSongDTO(dto: SongDTO): Song {
+  return {
+    id: String(dto.id),
+    title: dto.title,
+    fullTitle: `${dto.disc_no} / ${dto.title}`,
+    artistIds: dto.artist_ids.map(String),
+  };
+}
+```
+
+```ts title="entities/song/api/listSongs.ts"
+import { adaptSongDTO } from "./mapper";
+
+export function listSongs() {
+  return fetch('/api/songs').then(async (res) => (await res.json()).map(adaptSongDTO));
+}
+```
+
+```ts title="entities/song/model/songs.ts"
+import { createSlice, createEntityAdapter } from "@reduxjs/toolkit";
+
+import { listSongs } from "../api/listSongs";
+
+export const fetchSongs = createAsyncThunk('songs/fetchSongs', listSongs);
+
+const songAdapter = createEntityAdapter();
+const songsSlice = createSlice({
+  name: "songs",
+  initialState: songAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchSongs.fulfilled, (state, action) => {
+      songAdapter.upsertMany(state, action.payload);
+    })
+  },
+});
+```
+
+### Cách xử lý nested DTOs
+
+Phần có vấn đề nhất là khi response từ backend chứa nhiều entities. Ví dụ, nếu bài hát bao gồm không chỉ IDs của tác giả, mà cả toàn bộ author objects. Trong trường hợp này, không thể cho các entities không biết về nhau (trừ khi chúng ta muốn loại bỏ dữ liệu hoặc có cuộc trò chuyện nghiêm túc với backend team). Thay vì nghĩ ra giải pháp cho kết nối gián tiếp giữa các slices (như common middleware sẽ dispatch actions đến slices khác), ưu tiên cross-imports rõ ràng với ký hiệu `@x`. Đây là cách chúng ta có thể triển khai với Redux Toolkit:
+
+```ts title="entities/song/model/songs.ts"
+import {
+  createSlice,
+  createEntityAdapter,
+  createAsyncThunk,
+  createSelector,
+} from '@reduxjs/toolkit'
+import { normalize, schema } from 'normalizr'
+
+import { getSong } from "../api/getSong";
+
+// Định nghĩa normalizr entity schemas
+export const artistEntity = new schema.Entity('artists')
+export const songEntity = new schema.Entity('songs', {
+  artists: [artistEntity],
+})
+
+const songAdapter = createEntityAdapter()
+
+export const fetchSong = createAsyncThunk(
+  'songs/fetchSong',
+  async (id: string) => {
+    const data = await getSong(id)
+    // Normalize dữ liệu để reducers có thể load payload dự đoán được, như:
+    // `action.payload = { songs: {}, artists: {} }`
+    const normalized = normalize(data, songEntity)
+    return normalized.entities
+  }
+)
+
+export const slice = createSlice({
+  name: 'songs',
+  initialState: songAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchSong.fulfilled, (state, action) => {
+      songAdapter.upsertMany(state, action.payload.songs)
+    })
+  },
+})
+
+const reducer = slice.reducer
+export default reducer
+```
+
+```ts title="entities/song/@x/artist.ts"
+export { fetchSong } from "../model/songs";
+```
+
+```ts title="entities/artist/model/artists.ts"
+import { createSlice, createEntityAdapter } from '@reduxjs/toolkit'
+
+import { fetchSong } from 'entities/song/@x/artist'
+
+const artistAdapter = createEntityAdapter()
+
+export const slice = createSlice({
+  name: 'users',
+  initialState: artistAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchSong.fulfilled, (state, action) => {
+      // Và xử lý cùng fetch result bằng cách chèn artists ở đây
+      artistAdapter.upsertMany(state, action.payload.artists)
+    })
+  },
+})
+
+const reducer = slice.reducer
+export default reducer
+```
+
+Điều này hạn chế một chút lợi ích của slice isolation, nhưng nó thể hiện chính xác kết nối giữa hai entities này mà chúng ta không kiểm soát được. Nếu các entities này cần được refactor, chúng phải được refactor cùng nhau.
+
+## Global types và Redux
+
+Global types là types sẽ được sử dụng trong toàn bộ ứng dụng. Có hai loại global types, dựa trên những gì chúng cần biết:
+1. Generic types không có bất kỳ đặc điểm ứng dụng nào
+2. Types cần biết về toàn bộ ứng dụng
+
+Trường hợp đầu tiên đơn giản để giải quyết — đặt types của bạn trong Shared, trong segment phù hợp. Ví dụ, nếu bạn có interface cho global variable cho analytics, bạn có thể đặt nó trong `shared/analytics`.
+
+:::warning
+
+Tránh tạo folder `shared/types`. Nó nhóm những thứ không liên quan chỉ dựa trên thuộc tính "là một type", và thuộc tính đó thường không hữu ích khi tìm kiếm code trong dự án.
+
+:::
+
+Trường hợp thứ hai thường gặp trong các dự án với Redux không có RTK. Store type cuối cùng của bạn chỉ có sẵn khi bạn thêm tất cả reducers lại với nhau, nhưng store type này cần có sẵn cho selectors mà bạn sử dụng trong app. Ví dụ, đây là định nghĩa store điển hình của bạn:
+
+```ts title="app/store/index.ts"
+import { combineReducers, rootReducer } from "redux";
+
+import { songReducer } from "entities/song";
+import { artistReducer } from "entities/artist";
+
+const rootReducer = combineReducers(songReducer, artistReducer);
+
+const store = createStore(rootReducer);
+
+type RootState = ReturnType<typeof rootReducer>;
+type AppDispatch = typeof store.dispatch;
+```
+
+Sẽ tốt nếu có typed Redux hooks `useAppDispatch` và `useAppSelector` trong `shared/store`, nhưng chúng không thể import `RootState` và `AppDispatch` từ App layer do [import rule trên layers][import-rule-on-layers]:
+
+> Một module trong slice chỉ có thể import các slices khác khi chúng được đặt trên layers nghiêm ngặt bên dưới.
+
+Giải pháp được khuyến nghị trong trường hợp này là tạo implicit dependency giữa layers Shared và App. Hai types này, `RootState` và `AppDispatch` không chắc sẽ thay đổi, và chúng sẽ quen thuộc với Redux developers, vì vậy chúng ta không phải lo lắng về chúng nhiều.
+
+Trong TypeScript, bạn có thể làm điều đó bằng cách khai báo types là global như thế này:
+
+```ts title="app/store/index.ts"
+/* cùng nội dung như trong code block trước… */
+
+declare type RootState = ReturnType<typeof rootReducer>;
+declare type AppDispatch = typeof store.dispatch;
+```
+
+```ts title="shared/store/index.ts"
+import { useDispatch, useSelector, type TypedUseSelectorHook } from "react-redux";
+
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+```
+
+## Enums
+
+Quy tắc chung với enums là chúng nên được định nghĩa **càng gần với vị trí sử dụng càng tốt**. Khi enum đại diện cho các giá trị cụ thể cho một feature duy nhất, nó nên được định nghĩa trong cùng feature đó.
+
+Việc chọn segment cũng nên được quyết định bởi vị trí sử dụng. Nếu enum của bạn chứa, ví dụ, vị trí của toast trên màn hình, nó nên được đặt trong segment `ui`. Nếu nó đại diện cho loading state của backend operation, nó nên được đặt trong segment `api`.
+
+Một số enums thực sự chung cho toàn bộ dự án, như general backend response statuses hoặc design system tokens. Trong trường hợp này, bạn có thể đặt chúng trong Shared, và chọn segment dựa trên enum đại diện cho gì (`api` cho response statuses, `ui` cho design tokens, v.v.).
+
+## Type validation schemas và Zod
+
+Nếu bạn muốn validate rằng dữ liệu của bạn phù hợp với hình dạng hoặc ràng buộc nhất định, bạn có thể định nghĩa validation schema. Trong TypeScript, library phổ biến cho công việc này là [Zod][ext-zod]. Validation schemas cũng nên được colocated với code sử dụng chúng, càng nhiều càng tốt.
+
+Validation schemas tương tự như mappers (như đã thảo luận trong phần [Data transfer objects và mappers](#data-transfer-objects-and-mappers)) ở chỗ chúng nhận data transfer object và parse nó, tạo ra lỗi nếu parsing thất bại.
+
+Một trong những trường hợp phổ biến nhất của validation là cho dữ liệu đến từ backend. Thông thường, bạn muốn request thất bại khi dữ liệu không khớp với schema, vì vậy hợp lý khi đặt schema ở cùng nơi với request function, thường là segment `api`.
+
+Nếu dữ liệu của bạn đến qua user input, như form, validation nên xảy ra khi dữ liệu đang được nhập. Bạn có thể đặt schema trong segment `ui`, cạnh form component, hoặc trong segment `model`, nếu segment `ui` quá đông.
+
+## Typings của component props và context
+
+Nói chung, tốt nhất là giữ props hoặc context interface trong cùng file với component hoặc context sử dụng chúng. Nếu bạn có framework với single-file components, như Vue hoặc Svelte, và bạn không thể định nghĩa props interface trong cùng file, hoặc bạn muốn chia sẻ interface đó giữa nhiều components, tạo file riêng trong cùng folder, thường là segment `ui`.
+
+Đây là ví dụ với JSX (React hoặc Solid):
+
+```ts title="pages/home/ui/RecentActions.tsx"
+interface RecentActionsProps {
+  actions: Array<{ id: string; text: string }>;
+}
+
+export function RecentActions({ actions }: RecentActionsProps) {
+  /* … */
+}
+```
+
+Và đây là ví dụ với interface được lưu trong file riêng cho Vue:
+
+```ts title="pages/home/ui/RecentActionsProps.ts"
+export interface RecentActionsProps {
+  actions: Array<{ id: string; text: string }>;
+}
+```
+
+```html title="pages/home/ui/RecentActions.vue"
+<script setup lang="ts">
+  import type { RecentActionsProps } from "./RecentActionsProps";
+
+  const props = defineProps<RecentActionsProps>();
+</script>
+```
+
+## Ambient declaration files (`*.d.ts`)
+
+Một số packages, ví dụ, [Vite][ext-vite] hoặc [ts-reset][ext-ts-reset], yêu cầu ambient declaration files để hoạt động trong app của bạn. Thường thì chúng không lớn hoặc phức tạp, vì vậy chúng thường không yêu cầu bất kỳ architecting nào, có thể chỉ cần đặt chúng trong folder `src/`. Để giữ `src` có tổ chức hơn, bạn có thể giữ chúng trên App layer, trong `app/ambient/`.
+
+Các packages khác đơn giản là không có typings, và bạn có thể muốn khai báo chúng là untyped hoặc thậm chí viết typings riêng cho chúng. Nơi tốt cho những typings đó sẽ là `shared/lib`, trong folder như `shared/lib/untyped-packages`. Tạo file `%LIBRARY_NAME%.d.ts` ở đó và khai báo types bạn cần:
+
+```ts title="shared/lib/untyped-packages/use-react-screenshot.d.ts"
+// Library này không có typings, và chúng tôi không muốn phiền viết riêng.
+declare module "use-react-screenshot";
+```
+
+## Tự động sinh types
+
+Thường xuyên sinh types từ nguồn bên ngoài, ví dụ, sinh backend types từ OpenAPI schema. Trong trường hợp này, tạo nơi chuyên dụng trong codebase của bạn cho những types này, như `shared/api/openapi`. Lý tưởng nhất, bạn cũng nên bao gồm README trong folder đó mô tả những files này là gì, cách tái tạo chúng, v.v.
+
+[import-rule-on-layers]: /docs/reference/layers#import-rule-on-layers
+[ext-type-fest]: https://github.com/sindresorhus/type-fest
+[ext-zod]: https://zod.dev
+[ext-vite]: https://vitejs.dev
+[ext-ts-reset]: https://www.totaltypescript.com/ts-reset

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/white-labels.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/examples/white-labels.mdx
@@ -1,0 +1,18 @@
+---
+sidebar_position: 8
+sidebar_class_name: sidebar-item--wip
+unlisted: true
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# White Labels
+
+<WIP ticket="215" />
+
+> Figma, brand uikit, templates, adaptability to brands
+
+## See also
+
+- [(Thread) About the application for white-labels (branded) projects](https://t.me/feature_sliced/1543)
+- [(Presentation) About white-labels apps and design](http://yadi.sk/i/5IdhzsWrpO3v4Q)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/issues/_category_.yaml
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/issues/_category_.yaml
@@ -1,0 +1,2 @@
+label: Code smells & Vấn đề
+position: 4

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/issues/cross-imports.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/issues/cross-imports.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_position: 4
+sidebar_class_name: sidebar-item--wip
+pagination_next: reference/layers
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Cross-imports
+
+<WIP ticket="220" />
+
+> Cross-imports xuất hiện khi layer hoặc abstraction bắt đầu đảm nhận quá nhiều trách nhiệm hơn nó nên. Đó là lý do tại sao phương pháp luận xác định các layers mới cho phép bạn tách rời những cross-imports này
+
+## Xem thêm
+
+- [(Thread) Về tính không thể tránh khỏi của cross-ports](https://t.me/feature_sliced/4515)
+- [(Thread) Về việc giải quyết cross-ports trong entities](https://t.me/feature_sliced/3678)
+- [(Thread) Về cross-imports và responsibility](https://t.me/feature_sliced/3287)
+- [(Thread) Về imports giữa các segments](https://t.me/feature_sliced/4021)
+- [(Thread) Về cross-imports bên trong shared](https://t.me/feature_sliced/3618)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/issues/desegmented.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/issues/desegmented.mdx
@@ -1,0 +1,97 @@
+---
+sidebar_position: 2
+sidebar_class_name: sidebar-item--wip
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Desegmented
+
+<WIP ticket="148" />
+
+## Tình huống
+
+Rất thường xuyên xảy ra tình huống trên các project khi các module liên quan đến một domain cụ thể từ lĩnh vực chủ đề bị phân tách không cần thiết và nằm rải rác khắp project
+
+```sh
+├── components/
+|    ├── DeliveryCard
+|    ├── DeliveryChoice
+|    ├── RegionSelect
+|    ├── UserAvatar
+├── actions/
+|    ├── delivery.js
+|    ├── region.js
+|    ├── user.js
+├── epics/
+|    ├── delivery.js
+|    ├── region.js
+|    ├── user.js
+├── constants/
+|    ├── delivery.js
+|    ├── region.js
+|    ├── user.js
+├── helpers/
+|    ├── delivery.js
+|    ├── region.js
+|    ├── user.js
+├── entities/
+|    ├── delivery/
+|    |      ├── getters.js
+|    |      ├── selectors.js
+|    ├── region/
+|    ├── user/
+```
+
+## Vấn đề
+
+Vấn đề thể hiện ít nhất là vi phạm nguyên tắc **High Cohesion** và kéo dài quá mức **trục thay đổi**
+
+## Nếu bỏ qua
+
+- Nếu cần chạm vào logic, ví dụ delivery - chúng ta sẽ phải nhớ rằng nó nằm ở nhiều nơi và phải chạm vào nhiều chỗ trong code - điều này kéo dài không cần thiết **Trục thay đổi** của chúng ta
+- Nếu cần nghiên cứu logic của user, chúng ta sẽ phải đi khắp project để tìm hiểu chi tiết **actions, epics, constants, entities, components** - thay vì để nó nằm ở một chỗ
+- Các liên kết ngầm và sự mất kiểm soát của domain area đang phát triển
+- Với cách tiếp cận này, mắt rất dễ bị mờ đi và bạn có thể không nhận ra khi chúng ta "tạo constants vì constants", tạo ra một đống rác trong thư mục tương ứng của project
+
+## Giải pháp
+
+Đặt tất cả các module liên quan đến một domain/use case cụ thể - ngay cạnh nhau
+
+Để khi nghiên cứu một module cụ thể, tất cả các thành phần của nó nằm cạnh nhau, không bị rải rác khắp project
+
+> Điều này cũng tăng khả năng khám phá và sự rõ ràng của code base và mối quan hệ giữa các module
+
+```diff
+- ├── components/
+- |    ├── DeliveryCard
+- |    ├── DeliveryChoice
+- |    ├── RegionSelect
+- |    ├── UserAvatar
+- ├── actions/
+- |    ├── delivery.js
+- |    ├── region.js
+- |    ├── user.js
+- ├── epics/{...}
+- ├── constants/{...}
+- ├── helpers/{...}
+  ├── entities/
+  |    ├── delivery/
++ |    |      ├── ui/ # ~ components/
++ |    |      |   ├── card.js
++ |    |      |   ├── choice.js
++ |    |      ├── model/
++ |    |      |   ├── actions.js
++ |    |      |   ├── constants.js
++ |    |      |   ├── epics.js
++ |    |      |   ├── getters.js
++ |    |      |   ├── selectors.js
++ |    |      ├── lib/ # ~ helpers
+  |    ├── region/
+  |    ├── user/
+```
+
+## Xem thêm
+
+* [(Article) Về Low Coupling và High Cohesion một cách rõ ràng](https://enterprisecraftsmanship.com/posts/cohesion-coupling-difference/)
+* [(Article) Low Coupling và High Cohesion. Law of Demeter](https://medium.com/german-gorelkin/low-coupling-high-cohesion-d36369fb1be9)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/issues/routes.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/issues/routes.mdx
@@ -1,0 +1,46 @@
+---
+sidebar_position: 3
+sidebar_class_name: sidebar-item--wip
+---
+
+import WIP from '@site/src/shared/ui/wip/tmpl.mdx'
+
+# Routing
+
+<WIP ticket="169" />
+
+## Tình huống
+
+URL đến các trang được hardcode trong các layer bên dưới pages
+
+```tsx title="entities/post/card"
+
+<Card>
+    <Card.Title 
+        href={`/post/${data.id}`}
+        title={data.name}
+    />
+    ...
+</Card>
+```
+
+## Vấn đề
+
+URL không được tập trung trong layer pages, nơi chúng thuộc về theo phạm vi trách nhiệm
+
+## Nếu bỏ qua
+
+Khi thay đổi URL, bạn sẽ phải nhớ rằng các URL này (và logic của URL/redirect) có thể nằm ở tất cả các layer trừ pages
+
+Và điều đó cũng có nghĩa là giờ đây ngay cả một product card đơn giản cũng đảm nhận một phần trách nhiệm từ pages, làm mờ logic của project
+
+## Giải pháp
+
+Xác định cách làm việc với URL/redirect từ cấp độ page trở lên
+
+Chuyển xuống các layer bên dưới thông qua composition/props/factories
+
+## Xem thêm
+
+- [(Thread) Điều gì xảy ra nếu tôi "may" routing trong entities/features/widgets](https://t.me/feature_sliced/4389)
+- [(Thread) Tại sao nó làm mờ logic của routes chỉ trong pages](https://t.me/feature_sliced/3756)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/migration/_category_.yaml
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/migration/_category_.yaml
@@ -1,0 +1,2 @@
+label: Chuyển đổi
+position: 2

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/migration/from-custom.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/migration/from-custom.md
@@ -1,0 +1,313 @@
+---
+sidebar_position: 1
+sidebar_label: From a custom architecture
+---
+
+# Migration từ custom architecture
+
+Hướng dẫn này mô tả cách tiếp cận có thể hữu ích khi migration từ custom self-made architecture sang Feature-Sliced Design.
+
+Đây là cấu trúc folder của một custom architecture điển hình. Chúng tôi sẽ sử dụng nó làm ví dụ trong hướng dẫn này.  
+Nhấp vào mũi tên xanh để mở folder.
+
+<details className="file-tree">
+      <summary>📁 src</summary>
+      <ul>
+            <li>
+                  <details className="file-tree">
+                        <summary>📁 actions</summary>
+                        <ul>
+                              <li>📁 product</li>
+                              <li>📁 order</li>
+                        </ul>
+                  </details>
+            </li>
+            <li>📁 api</li>
+            <li>📁 components</li>
+            <li>📁 containers</li>
+            <li>📁 constants</li>
+            <li>📁 i18n</li>
+            <li>📁 modules</li>
+            <li>📁 helpers</li>
+            <li>
+                  <details className="file-tree">
+                        <summary>📁 routes</summary>
+                        <ul>
+                              <li>📁 products.jsx</li>
+                              <li>📄 products.[id].jsx</li>
+                        </ul>
+                  </details>
+            </li>
+            <li>📁 utils</li>
+            <li>📁 reducers</li>
+            <li>📁 selectors</li>
+            <li>📁 styles</li>
+            <li>📄 App.jsx</li>
+            <li>📄 index.js</li>
+      </ul>
+</details>
+
+## Trước khi bạn bắt đầu {#before-you-start}
+
+Câu hỏi quan trọng nhất để hỏi team của bạn khi cân nhắc chuyển sang Feature-Sliced Design là — _bạn có thực sự cần nó không?_ Chúng tôi yêu Feature-Sliced Design, nhưng thậm chí chúng tôi cũng nhận ra rằng một số dự án hoàn toàn ổn mà không cần nó.
+
+Đây là một số lý do để cân nhắc thực hiện sự chuyển đổi:
+
+1. Thành viên mới trong team phàn nàn rằng khó đạt đến mức độ hiệu quả
+2. Thực hiện modifications ở một phần của code **thường** gây ra phần khác không liên quan bị hỏng
+3. Thêm functionality mới khó khăn do số lượng lớn các thứ bạn cần suy nghĩ
+
+**Tránh chuyển sang FSD trái với ý muốn của các đồng đội**, ngay cả khi bạn là lead.  
+Trước tiên, hãy thuyết phục các đồng đội rằng lợi ích vượt trội so với chi phí migration và chi phí học một architecture mới thay vì architecture đã được thiết lập.
+
+Cũng cần nhớ rằng bất kỳ loại thay đổi kiến trúc nào cũng không ngay lập tức có thể quan sát được đối với quản lý. Hãy đảm bảo họ đồng ý với việc chuyển đổi trước khi bắt đầu và giải thích cho họ tại sao điều này có thể có lợi cho dự án.
+
+:::tip
+
+Nếu bạn cần giúp để thuyết phục project manager rằng FSD có lợi, hãy cân nhắc một số điểm này:
+1. Migration sang FSD có thể diễn ra dần dần, vì vậy nó sẽ không dừng việc phát triển các tính năng mới
+2. Một architecture tốt có thể giảm đáng kể thời gian mà một developer mới cần để trở nên hiệu quả
+3. FSD là một architecture được tài liệu hóa, vì vậy team không phải liên tục dành thời gian để duy trì documentation riêng của họ
+
+:::
+
+---
+
+Nếu bạn đã quyết định bắt đầu migration, thì điều đầu tiên bạn muốn làm là thiết lập một alias cho `📁 src`. Điều này sẽ hữu ích sau này khi tham chiếu đến các folder tầng cao. Chúng tôi sẽ coi `@` là alias cho `./src` trong phần còn lại của hướng dẫn này.
+
+## Bước 1. Chia code theo pages {#divide-code-by-pages}
+
+Hầu hết custom architectures đã có sự phân chia theo pages, dù logic nhỏ hay lớn. Nếu bạn đã có `📁 pages`, bạn có thể bỏ qua bước này.
+
+Nếu bạn chỉ có `📁 routes`, hãy tạo `📁 pages` và cố gắng di chuyển càng nhiều component code từ `📁 routes` càng tốt. Lý tưởng là bạn sẽ có một route nhỏ và một page lớn hơn. Khi đang di chuyển code, hãy tạo một folder cho mỗi page và thêm một index file:
+
+:::note
+
+Hiện tại, không sao nếu các page của bạn tham chiếu lẫn nhau. Bạn có thể giải quyết điều đó sau, nhưng hiện tại, hãy tập trung vào việc thiết lập một sự phân chia rõ ràng theo pages.
+
+:::
+
+Route file:
+
+```js title="src/routes/products.[id].js"
+export { ProductPage as default } from "@/pages/product"
+```
+
+Page index file:
+
+```js title="src/pages/product/index.js"
+export { ProductPage } from "./ProductPage.jsx"
+```
+
+Page component file:
+
+```jsx title="src/pages/product/ProductPage.jsx"
+export function ProductPage(props) {
+  return <div />;
+}
+```
+
+## Bước 2. Tách mọi thứ khác ra khỏi pages {#separate-everything-else-from-pages}
+
+Tầo folder `📁 src/shared` và di chuyển mọi thứ không import từ `📁 pages` hoặc `📁 routes` vào đó. Tạo folder `📁 src/app` và di chuyển mọi thứ có import pages hoặc routes vào đó, bao gồm cả chính các routes.
+
+Hãy nhớ rằng Shared layer không có slices, vì vậy không sao nếu các segment import lẫn nhau.
+
+Cuối cùng bạn sẽ có được cấu trúc tệp như thế này:
+
+<details className="file-tree" open>
+      <summary>📁 src</summary>
+      <ul>
+            <li>
+                  <details className="file-tree">
+                        <summary>📁 app</summary>
+                        <ul>
+                              <li>
+                                    <details className="file-tree">
+                                          <summary>📁 routes</summary>
+                                          <ul>
+                                                <li>📄 products.jsx</li>
+                                                <li>📄 products.[id].jsx</li>
+                                          </ul>
+                                    </details>
+                              </li>
+                              <li>📄 App.jsx</li>
+                              <li>📄 index.js</li>
+                        </ul>
+                  </details>
+            </li>
+            <li>
+                  <details className="file-tree">
+                        <summary>📁 pages</summary>
+                        <ul>
+                              <li>
+                                    <details className="file-tree">
+                                          <summary>📁 product</summary>
+                                          <ul>
+                                                <li>
+                                                      <details className="file-tree">
+                                                            <summary>📁 ui</summary>
+                                                            <ul>
+                                                                  <li>📄 ProductPage.jsx</li>
+                                                            </ul>
+                                                      </details>
+                                                </li>
+                                                <li>📄 index.js</li>
+                                          </ul>
+                                    </details>
+                              </li>
+                              <li>📁 catalog</li>
+                        </ul>
+                  </details>
+            </li>
+            <li>
+                  <details className="file-tree">
+                        <summary>📁 shared</summary>
+                        <ul>
+                              <li>📁 actions</li>
+                              <li>📁 api</li>
+                              <li>📁 components</li>
+                              <li>📁 containers</li>
+                              <li>📁 constants</li>
+                              <li>📁 i18n</li>
+                              <li>📁 modules</li>
+                              <li>📁 helpers</li>
+                              <li>📁 utils</li>
+                              <li>📁 reducers</li>
+                              <li>📁 selectors</li>
+                              <li>📁 styles</li>
+                        </ul>
+                  </details>
+            </li>
+      </ul>
+</details>
+
+## Bước 3. Giải quyết cross-imports giữa các pages {#tackle-cross-imports-between-pages}
+
+<!-- A good way to approach this is by setting up [Steiger][ext-steiger], the linter for FSD.  -->
+<!-- TODO: add instructions once the new config format is standardized -->
+
+Tìm tất cả các trường hợp mà một page đang import từ page khác và làm một trong hai điều sau:
+
+1. Copy-paste code được import vào page phụ thuộc để loại bỏ dependency
+2. Di chuyển code vào một segment thích hợp trong Shared: 
+      - nếu nó là một phần của UI kit, di chuyển vào `📁 shared/ui`; 
+      - nếu nó là một configuration constant, di chuyển vào `📁 shared/config`; 
+      - nếu nó là một backend interaction, di chuyển vào `📁 shared/api`.
+
+:::note
+
+**Copy-pasting không sai về mặt kiến trúc**, thực tế, đôi khi duplicate có thể chính xác hơn là abstract thành một reusable module mới. Lý do là đôi khi các phần shared của pages bắt đầu tách rời, và bạn không muốn các dependency cản trở bạn trong những trường hợp này.
+
+Tuy nhiên, vẫn còn ý nghĩa trong nguyên tắc DRY ("don't repeat yourself"), vì vậy hãy đảm bảo bạn không copy-paste business logic. Nếu không bạn sẽ cần phải nhớ sửa bug ở nhiều nơi cùng lúc.
+
+:::
+
+## Bước 4. Giải nén Shared layer {#unpack-shared-layer}
+
+Bạn có thể có rất nhiều thứ trong Shared layer ở bước này, và nói chung bạn muốn tránh điều đó. Lý do là Shared layer có thể là dependency cho bất kỳ layer nào khác trong codebase của bạn, vì vậy việc thay đổi code đó tự động dễ gây ra các hậu quả ngoài ý muốn hơn.
+
+Tìm tất cả các object chỉ được sử dụng trên một page và di chuyển nó vào slice của page đó. Và đúng rồi, _điều đó cũng áp dụng cho actions, reducers, và selectors_. Không có lợi ích gì khi nhóm tất cả actions lại với nhau, nhưng có lợi ích khi đặt các relevant actions gần với nơi sử dụng chúng.
+
+Cuối cùng bạn sẽ có được cấu trúc tệp như thế này:
+
+<details className="file-tree" open>
+      <summary>📁 src</summary>
+      <ul>
+            <li>📁 app (unchanged)</li>
+            <li>
+                  <details className="file-tree" open>
+                        <summary>📁 pages</summary>
+                        <ul>
+                              <li>
+                                    <details className="file-tree" open>
+                                          <summary>📁 product</summary>
+                                          <ul>
+                                                <li>📁 actions</li>
+                                                <li>📁 reducers</li>
+                                                <li>📁 selectors</li>
+                                                <li>
+                                                      <details className="file-tree">
+                                                            <summary>📁 ui</summary>
+                                                            <ul>
+                                                                  <li>📄 Component.jsx</li>
+                                                                  <li>📄 Container.jsx</li>
+                                                                  <li>📄 ProductPage.jsx</li>
+                                                            </ul>
+                                                      </details>
+                                                </li>
+                                                <li>📄 index.js</li>
+                                          </ul>
+                                    </details>
+                              </li>
+                              <li>📁 catalog</li>
+                        </ul>
+                  </details>
+            </li>
+            <li>
+                  <details className="file-tree">
+                        <summary>📁 shared (only objects that are reused)</summary>
+                        <ul>
+                              <li>📁 actions</li>
+                              <li>📁 api</li>
+                              <li>📁 components</li>
+                              <li>📁 containers</li>
+                              <li>📁 constants</li>
+                              <li>📁 i18n</li>
+                              <li>📁 modules</li>
+                              <li>📁 helpers</li>
+                              <li>📁 utils</li>
+                              <li>📁 reducers</li>
+                              <li>📁 selectors</li>
+                              <li>📁 styles</li>
+                        </ul>
+                  </details>
+            </li>
+      </ul>
+</details>
+
+## Bước 5. Tổ chức code theo mục đích kỹ thuật {#organize-by-technical-purpose}
+
+Trong FSD, việc phân chia theo mục đích kỹ thuật được thực hiện với _segments_. Có một số loại phổ biến:
+
+- `ui` — mọi thứ liên quan đến hiển thị UI: UI components, date formatters, styles, v.v.
+- `api` — các tương tác backend: request functions, data types, mappers, v.v.
+- `model` — data model: schemas, interfaces, stores, và business logic.
+- `lib` — library code mà các module khác trên slice này cần.
+- `config` — các file cấu hình và feature flags.
+
+Bạn cũng có thể tạo các segment riêng của mình nếu cần. Hãy đảm bảo không tạo các segment nhóm code theo những gì nó là, như `components`, `actions`, `types`, `utils`. Thay vào đó, hãy nhóm code theo những gì nó dành cho.
+
+Tổ chức lại các pages của bạn để tách biệt code theo segments. Bạn nên đã có một `ui` segment, bây giờ là lúc tạo các segment khác, như `model` cho actions, reducers, và selectors của bạn, hoặc `api` cho thunks và mutations của bạn.
+
+Cũng tổ chức lại Shared layer để loại bỏ các folder này:
+- `📁 components`, `📁 containers` — phần lớn nó nên trở thành `📁 shared/ui`;
+- `📁 helpers`, `📁 utils` — nếu còn một số helpers được tái sử dụng, hãy nhóm chúng lại theo function, như dates hoặc type conversions, và di chuyển các nhóm này vào `📁 shared/lib`;
+- `📁 constants` — lại, nhóm theo function và di chuyển vào `📁 shared/config`.
+
+## Các bước tùy chọn {#optional-steps}
+
+### Bước 6. Tạo entities/features từ các Redux slice được sử dụng trên nhiều pages {#form-entities-features-from-redux}
+
+Thường thì các Redux slice được tái sử dụng này sẽ mô tả điều gì đó liên quan đến nghiệp vụ, ví dụ như products hoặc users, vì vậy chúng có thể được di chuyển vào Entities layer, một entity một folder. Nếu Redux slice liên quan đến một action mà người dùng của bạn muốn thực hiện trong app, như comments, thì bạn có thể di chuyển nó vào Features layer.
+
+Entities và features có ý định độc lập với nhau. Nếu business domain của bạn chứa các kết nối bẩm sinh giữa các entity, hãy tham khảo [hướng dẫn về business entities][business-entities-cross-relations] để có lời khuyên về cách tổ chức các kết nối này.
+
+Các API functions liên quan đến các slice này có thể giữ lại trong `📁 shared/api`.
+
+### Bước 7. Refactor các modules của bạn {#refactor-your-modules}
+
+Folder `📁 modules` thường được sử dụng cho business logic, vì vậy nó đã khá tương tự về bản chất với Features layer từ FSD. Một số module cũng có thể mô tả những khối lớn của UI, như app header. Trong trường hợp đó, bạn nên migration chúng vào Widgets layer.
+
+### Bước 8. Tạo một UI foundation sạch trong `shared/ui` {#form-clean-ui-foundation}
+
+`📁 shared/ui` lý tưởng nên chứa một tập hợp các UI elements không có business logic nào được encode trong chúng. Chúng cũng nên có tính tái sử dụng cao.
+
+Refactor các UI components đã từng nằm trong `📁 components` và `📁 containers` để tách riêng business logic. Di chuyển business logic đó lên các layer cao hơn. Nếu nó không được sử dụng ở quá nhiều nơi, bạn thậm chí có thể cân nhắc copy-paste.
+
+## Xem thêm {#see-also}
+
+- [(Bài nói tiếng Nga) Ilya Klimov — Крысиные бега бесконечного рефакторинга: как не дать техническому долгу убить мотивацию и продукт](https://youtu.be/aOiJ3k2UvO4)
+
+[ext-steiger]: https://github.com/feature-sliced/steiger
+[business-entities-cross-relations]: /docs/guides/examples/types#business-entities-and-their-cross-references

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/migration/from-v1.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/migration/from-v1.md
@@ -1,0 +1,171 @@
+---
+sidebar_position: 2
+---
+
+# Migration từ v1 sang v2
+
+## Tại sao v2?
+
+Khái niệm gốc của **feature-slices** [đã được công bố][ext-tg-spb] vào năm 2018.
+
+Kể từ đó, nhiều sự biến đổi của phương pháp luận đã diễn ra, nhưng đồng thời **[các nguyên tắc cơ bản đã được bảo tồn][ext-v1]**:
+
+- Sử dụng cấu trúc dự án frontend *được tiêu chuẩn hóa*
+- Chia nhỏ ứng dụng ngay từ đầu - theo *logic nghiệp vụ*
+- Sử dụng các *feature độc lập* để ngăn chặn side effects ngầm định và phụ thuộc vòng tròn
+- Sử dụng *Public API* với việc cấm "leo vào bên trong" của module
+
+Đồng thời, trong phiên bản trước của phương pháp luận, vẫn còn những **điểm yếu** mà:
+
+- Đôi khi dẫn đến boilerplate code
+- Đôi khi dẫn đến sự phức tạp quá mức của code base và các quy tắc không rõ ràng giữa các abstraction
+- Đôi khi dẫn đến các giải pháp kiến trúc ngầm định, ngăn cản việc kéo dự án lên và onboarding người mới
+
+Phiên bản mới của phương pháp luận ([v2][ext-v2]) được thiết kế **để loại bỏ những thiếu sót này, đồng thời bảo tồn các ưu điểm hiện có** của cách tiếp cận này.
+
+Kể từ năm 2018, [cũng đã phát triển][ext-fdd-issues] một phương pháp luận tương tự khác - [**feature-driven**][ext-fdd], được công bố lần đầu bởi [Oleg Isonen][ext-kof].
+
+Sau khi hợp nhất hai cách tiếp cận, chúng tôi đã **cải thiện và tinh chỉnh các thực tiễn hiện có** - hướng tới sự linh hoạt, rõ ràng và hiệu quả hơn trong ứng dụng.
+
+> Kết quả là, điều này thậm chí đã ảnh hưởng đến tên của phương pháp luận - *"feature-slice**d**"*
+
+## Tại sao việc migration dự án sang v2 có ý nghĩa?
+
+> `WIP:` Phiên bản hiện tại của phương pháp luận đang được phát triển và một số chi tiết *có thể thay đổi*
+
+#### 🔍 Kiến trúc minh bạch và đơn giản hơn
+
+Phương pháp luận (v2) cung cấp **các abstraction trực quan hơn và phổ biến hơn cũng như các cách phân tách logic giữa các developer.**
+
+Tất cả điều này có tác động cực kỳ tích cực đến việc thu hút người mới, cũng như nghiên cứu trạng thái hiện tại của dự án, và phân phối logic nghiệp vụ của ứng dụng.
+
+#### 📦 Tính modular linh hoạt và trung thực hơn
+
+Phương pháp luận (v2) cho phép **phân phối logic theo cách linh hoạt hơn:**
+
+- Với khả năng refactor các phần riêng biệt từ đầu
+- Với khả năng dựa vào cùng các abstraction, nhưng không có sự đan xen phụ thuộc không cần thiết
+- Với các yêu cầu đơn giản hơn cho vị trí của module mới *(layer => slice => segment)*
+
+#### 🚀 Nhiều đặc tả, kế hoạch, cộng đồng hơn
+
+Hiện tại, `core-team` đang tích cực làm việc trên phiên bản mới nhất (v2) của phương pháp luận
+
+Vì vậy đối với nó:
+
+- sẽ có nhiều case / vấn đề được mô tả hơn
+- sẽ có nhiều hướng dẫn về ứng dụng hơn
+- sẽ có nhiều ví dụ thực tế hơn
+- nói chung, sẽ có nhiều tài liệu hơn để onboarding người mới và nghiên cứu các khái niệm của phương pháp luận
+- toolkit sẽ được phát triển trong tương lai để tuân thủ các khái niệm và quy ước về kiến trúc
+
+> Tất nhiên, cũng sẽ có hỗ trợ người dùng cho phiên bản đầu tiên - nhưng phiên bản mới nhất vẫn là ưu tiên của chúng tôi
+>
+> Trong tương lai, với các bản cập nhật major tiếp theo, bạn vẫn sẽ có quyền truy cập vào phiên bản hiện tại (v2) của phương pháp luận, **không có rủi ro cho team và dự án của bạn**
+
+## Changelog
+
+### `BREAKING` Layers
+
+Bây giờ phương pháp luận giả định việc phân bổ rõ ràng các layer ở tầng cao nhất
+
+- `/app` > `/processes` > **`/pages`** > **`/features`** > `/entities` > `/shared`
+- *Tức là, không phải mọi thứ bây giờ đều được coi là features/pages*
+- Cách tiếp cận này cho phép bạn [đặt quy tắc rõ ràng cho các layer][ext-tg-v2-draft]:
+- **Càng cao layer** của module được đặt, càng nhiều **context** nó có
+  
+  *(nói cách khác - mỗi module của layer - chỉ có thể import các module của các layer bên dưới, nhưng không phải cao hơn)*
+
+- **Càng thấp layer** của module được đặt, càng nhiều **nguy hiểm và trách nhiệm** khi thực hiện thay đổi
+
+  *(vì thường là các layer bên dưới được sử dụng nhiều hơn)*
+
+### `BREAKING` Shared
+
+Các infrastructure abstraction `/ui`, `/lib`, `/api`, trước đây nằm trong src root của dự án, bây giờ được tách biệt bởi thư mục riêng biệt `/src/shared`
+
+- `shared/ui` - Vẫn là uikit tổng quát giống như cũ của ứng dụng (tùy chọn)
+  - *Đồng thời, không ai cấm sử dụng `Atomic Design` ở đây như trước*
+- `shared/lib` - Tập hợp các thư viện phụ trợ để triển khai logic
+  - *Vẫn - không có dump của helpers*
+- `shared/api` - Điểm vào chung để truy cập API
+  - *Cũng có thể đăng ký cục bộ trong mỗi feature / page - nhưng không được khuyến khích*
+- Như trước - không nên có ràng buộc rõ ràng với business logic trong `shared`
+  - *Nếu cần thiết, bạn cần đưa mối quan hệ này lên tầng `entities` hoặc thậm chí cao hơn*
+
+### `NEW` Entities, Processes
+
+Trong v2 **, các abstraction mới khác** đã được thêm vào để loại bỏ các vấn đề về độ phức tạp logic và coupling cao.
+
+- `/entities` - layer **business entities** chứa các slice có liên quan trực tiếp đến các business model hoặc synthetic entities chỉ cần thiết trên frontend
+  - *Ví dụ: `user`, `i18n`, `order`, `blog`*
+- `/processes` - layer **business processes**, xuyên suốt app
+  - **Layer này là tùy chọn**, thường được khuyến khích sử dụng khi *logic phát triển và bắt đầu mờ nhạt trong nhiều page*
+  - *Ví dụ: `payment`, `auth`, `quick-tour`*
+
+### `BREAKING` Abstractions & Naming
+
+Bây giờ các abstraction cụ thể và [khuyến nghị rõ ràng cho việc đặt tên chúng][refs-adaptability] đã được định nghĩa
+
+[disc-process]: https://github.com/feature-sliced/documentation/discussions/20
+[disc-features]: https://github.com/feature-sliced/documentation/discussions/23
+[disc-entities]: https://github.com/feature-sliced/documentation/discussions/18#discussioncomment-422649
+[disc-shared]: https://github.com/feature-sliced/documentation/discussions/31#discussioncomment-453020
+
+[disc-ui]: https://github.com/feature-sliced/documentation/discussions/31#discussioncomment-453132
+[disc-model]: https://github.com/feature-sliced/documentation/discussions/31#discussioncomment-472645
+[disc-api]: https://github.com/feature-sliced/documentation/discussions/66
+
+#### Layers
+
+- `/app` — **layer khởi tạo ứng dụng**
+  - *Các phiên bản trước: `app`, `core`,`init`, `src/index` (và điều này cũng xảy ra)*
+- `/processes` — [**layer business process**][disc-process]
+  - *Các phiên bản trước: `processes`, `flows`, `workflows`*
+- `/pages` — **layer page ứng dụng**
+  - *Các phiên bản trước: `pages`, `screens`, `views`, `layouts`, `components`, `containers`*
+- `/features` — [**layer các phần functionality**][disc-features]
+  - *Các phiên bản trước: `features`, `components`, `containers`*
+- `/entities` — [**layer business entity**][disc-entities]
+  - *Các phiên bản trước: `entities`, `models`, `shared`*
+- `/shared` — [**layer của infrastructure code tái sử dụng**][disc-shared] 🔥
+  - *Các phiên bản trước: `shared`, `common`, `lib`*
+
+#### Segments
+
+- `/ui` — [**UI segment**][disc-ui] 🔥
+  - *Các phiên bản trước: `ui`, `components`, `view`*
+- `/model` — [**BL-segment**][disc-model] 🔥
+  - *Các phiên bản trước: `model`, `store`, `state`, `services`, `controller`*
+- `/lib` — segment **của auxiliary code**
+  - *Các phiên bản trước: `lib`, `libs`, `utils`, `helpers`*
+- `/api` — [**API segment**][disc-api]
+  - *Các phiên bản trước: `api`, `service`, `requests`, `queries`*
+- `/config` — **segment cấu hình ứng dụng**
+  - *Các phiên bản trước: `config`, `env`, `get-env`*
+
+### `REFINED` Low coupling
+
+Bây giờ việc [tuân thủ nguyên tắc low coupling][refs-low-coupling] giữa các module dễ dàng hơn nhiều, nhờ vào các layer mới.
+
+*Đồng thời, vẫn được khuyến khích tránh càng nhiều càng tốt các trường hợp khi cực kỳ khó để "uncouple" các module*
+
+## Xem thêm
+
+- [Ghi chú từ báo cáo "React SPB Meetup #1"][ext-tg-spb]
+- [React Berlin Talk - Oleg Isonen "Feature Driven Architecture"][ext-kof-fdd]
+- [So sánh với v1 (community-chat)](https://t.me/feature_sliced/493)
+- [Ý tưởng mới v2 với giải thích (atomicdesign-chat)][ext-tg-v2-draft]
+- [Thảo luận về các abstraction và naming cho phiên bản mới của phương pháp luận (v2)](https://github.com/feature-sliced/documentation/discussions/31)
+
+[refs-low-coupling]: /docs/reference/slices-segments#zero-coupling-high-cohesion
+[refs-adaptability]: /docs/about/understanding/naming
+
+[ext-v1]: https://feature-sliced.github.io/featureslices.dev/v1.0.html
+[ext-tg-spb]: https://t.me/feature_slices
+[ext-fdd]: https://github.com/feature-sliced/documentation/tree/rc/feature-driven
+[ext-fdd-issues]: https://github.com/kof/feature-driven-architecture/issues
+[ext-v2]: https://github.com/feature-sliced/documentation
+[ext-kof]: https://github.com/kof
+[ext-kof-fdd]: https://www.youtube.com/watch?v=BWAeYuWFHhs
+[ext-tg-v2-draft]: https://t.me/atomicdesign/18708

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/migration/from-v2-0.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/migration/from-v2-0.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 3
+---
+
+# Migration từ v2.0 sang v2.1
+
+Thay đổi chính trong v2.1 là mental model mới để phân tách interface — pages first.
+
+Trong v2.0, FSD khuyến nghị xác định entities và features trong interface của bạn, cân nhắc thậm chí những bit nhỏ nhất của entity representation và tính tương tác để phân tách. Sau đó bạn sẽ xây dựng widgets và pages từ entities và features. Trong model phân tách này, phần lớn logic nằm trong entities và features, và pages chỉ là các compositional layer không có nhiều ý nghĩa riêng biệt.
+
+Trong v2.1, chúng tôi khuyến nghị bắt đầu với pages, và có thể thậm chí dừng lại ở đó. Hầu hết mọi người đã biết cách tách app thành các page riêng biệt, và pages cũng là điểm khởi đầu phổ biến khi cố gắng tìm một component trong codebase. Trong model phân tách mới này, bạn giữ phần lớn UI và logic trong mỗi page riêng biệt, duy trì một foundation có thể tái sử dụng trong Shared. Nếu phát sinh nhu cầu tái sử dụng business logic trên nhiều page, bạn có thể di chuyển nó xuống layer bên dưới.
+
+Một bổ sung khác cho Feature-Sliced Design là việc tiêu chuẩn hóa cross-imports giữa các entity với ký hiệu `@x`.
+
+## Cách migration {#how-to-migrate}
+
+Không có breaking changes trong v2.1, điều này có nghĩa là một dự án được viết với FSD v2.0 cũng là một dự án hợp lệ trong FSD v2.1. Tuy nhiên, chúng tôi tin rằng mental model mới có lợi hơn cho các team và đặc biệt là onboarding các developer mới, vì vậy chúng tôi khuyến nghị thực hiện các điều chỉnh nhỏ đối với việc phân tách của bạn.
+
+### Merge slices
+
+Một cách đơn giản để bắt đầu là chạy linter của chúng tôi, [Steiger][steiger], trên dự án. Steiger được xây dựng với mental model mới, và các rule hữu ích nhất sẽ là:
+
+- [`insignificant-slice`][insignificant-slice] — nếu một entity hoặc feature chỉ được sử dụng trong một page, rule này sẽ đề xuất merge entity hoặc feature đó hoàn toàn vào page.
+- [`excessive-slicing`][excessive-slicing] — nếu một layer có quá nhiều slices, thường là dấu hiệu cho thấy việc phân tách quá chi tiết. Rule này sẽ đề xuất merge hoặc nhóm một số slices để hỗ trợ navigation dự án.
+
+```bash
+npx steiger src
+```
+
+Điều này sẽ giúp bạn xác định những slice chỉ được sử dụng một lần, để bạn có thể cân nhắc lại xem chúng có thực sự cần thiết không. Trong những cân nhắc như vậy, hãy nhớ rằng một layer tạo thành một loại global namespace cho tất cả các slice bên trong nó. Giống như bản sẽ không làm ô nhiễm global namespace với các biến chỉ được sử dụng một lần, bạn nên coi một vị trí trong namespace của layer là có giá trị, được sử dụng một cách tiết kiệm.
+
+### Tiêu chuẩn hóa cross-imports
+
+Nếu trước đây bạn đã có cross-imports giữa trong dự án của mình (chúng tôi không phán xét!), bây giờ bạn có thể tận dụng một ký hiệu mới cho cross-importing trong Feature-Sliced Design — ký hiệu `@x`. Nó trông như thế này:
+
+```ts title="entities/B/some/file.ts"
+import type { EntityA } from "entities/A/@x/B";
+```
+
+Để biết thêm chi tiết, hãy xem phần [Public API for cross-imports][public-api-for-cross-imports] trong reference.
+
+[insignificant-slice]: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/insignificant-slice
+[steiger]: https://github.com/feature-sliced/steiger
+[excessive-slicing]: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/excessive-slicing
+[public-api-for-cross-imports]: /docs/reference/public-api#public-api-for-cross-imports

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/_category_.yaml
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/_category_.yaml
@@ -1,0 +1,2 @@
+label: Công nghệ
+position: 3

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/with-electron.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/with-electron.mdx
@@ -1,0 +1,134 @@
+---
+sidebar_position: 10
+---
+# Sử dụng với Electron
+
+Các ứng dụng Electron có kiến trúc đặc biệt gồm nhiều process với các trách nhiệm khác nhau. Việc áp dụng FSD trong bối cảnh như vậy yêu cầu phải thích nghi cấu trúc với các đặc điểm của Electron.
+
+```sh
+└── src
+    ├── app                                 # Common app layer
+    │   ├── main                            # Main process
+    │   │   └── index.ts                    # Main process entry point
+    │   ├── preload                         # Preload script and Context Bridge
+    │   │   └── index.ts                    # Preload entry point
+    │   └── renderer                        # Renderer process
+    │       └── index.html                  # Renderer process entry point
+    ├── main
+    │   ├── features
+    │   │   └── user
+    │   │       └── ipc
+    │   │           ├── get-user.ts
+    │   │           └── send-user.ts
+    │   ├── entities
+    │   └── shared
+    ├── renderer
+    │   ├── pages
+    │   │   ├── settings
+    │   │   │   ├── ipc
+    │   │   │   │   ├── get-user.ts
+    │   │   │   │   └── save-user.ts
+    │   │   │   ├── ui
+    │   │   │   │   └── user.tsx
+    │   │   │   └── index.ts
+    │   │   └── home
+    │   │       ├── ui
+    │   │       │   └── home.tsx
+    │   │       └── index.ts
+    │   ├── widgets
+    │   ├── features
+    │   ├── entities
+    │   └── shared
+    └── shared                              # Common code between main and renderer
+        └── ipc                             # IPC description (event names, contracts)
+```
+
+## Quy tắc Public API
+Mỗi process phải có public API riêng của nó. Ví dụ, bạn không thể import các module từ `main` vào `renderer`.
+Chỉ có thư mục `src/shared` là public cho cả hai process.
+Nó cũng cần thiết để mô tả các hợp đồng cho tương tác giữa các process.
+
+## Các thay đổi bổ sung cho cấu trúc chuẩn
+Được đề xuất sử dụng segment `ipc` mới, nơi diễn ra tương tác giữa các process.
+Các layer `pages` và `widgets`, dựa trên tên gọi của chúng, không nên có mặt trong `src/main`. Bạn có thể sử dụng `features`, `entities` và `shared`.
+Layer `app` trong `src` chứa các điểm đầu vào cho `main` và `renderer`, cũng như IPC.
+Không mong muốn các segment trong layer `app` có điểm giao nhau
+
+## Ví dụ về tương tác
+
+```typescript title="src/shared/ipc/channels.ts"
+export const CHANNELS = {
+    GET_USER_DATA: 'GET_USER_DATA',
+    SAVE_USER: 'SAVE_USER',
+} as const;
+
+export type TChannelKeys = keyof typeof CHANNELS;
+```
+
+```typescript title="src/shared/ipc/events.ts"
+import { CHANNELS } from './channels';
+
+export interface IEvents {
+    [CHANNELS.GET_USER_DATA]: {
+        args: void,
+        response?: { name: string; email: string; };
+    };
+    [CHANNELS.SAVE_USER]: {
+        args: { name: string; };
+        response: void;
+    };
+}
+```
+
+```typescript title="src/shared/ipc/preload.ts"
+import { CHANNELS } from './channels';
+import type { IEvents } from './events';
+
+type TOptionalArgs<T> = T extends void ? [] : [args: T];
+
+export type TElectronAPI = {
+    [K in keyof typeof CHANNELS]: (...args: TOptionalArgs<IEvents[typeof CHANNELS[K]]['args']>) => IEvents[typeof CHANNELS[K]]['response'];
+};
+```
+
+```typescript title="src/app/preload/index.ts"
+import { contextBridge, ipcRenderer } from 'electron';
+import { CHANNELS, type TElectronAPI } from 'shared/ipc';
+
+const API: TElectronAPI = {
+    [CHANNELS.GET_USER_DATA]: () => ipcRenderer.sendSync(CHANNELS.GET_USER_DATA),
+    [CHANNELS.SAVE_USER]: args => ipcRenderer.invoke(CHANNELS.SAVE_USER, args),
+} as const;
+
+contextBridge.exposeInMainWorld('electron', API);
+```
+
+```typescript title="src/main/features/user/ipc/send-user.ts"
+import { ipcMain } from 'electron';
+import { CHANNELS } from 'shared/ipc';
+
+export const sendUser = () => {
+    ipcMain.on(CHANNELS.GET_USER_DATA, ev => {
+        ev.returnValue = {
+            name: 'John Doe',
+            email: 'john.doe@example.com',
+        };
+    });
+};
+```
+
+```typescript title="src/renderer/pages/user-settings/ipc/get-user.ts"
+import { CHANNELS } from 'shared/ipc';
+
+export const getUser = () => {
+    const user = window.electron[CHANNELS.GET_USER_DATA]();
+
+    return user ?? { name: 'John Donte', email: 'john.donte@example.com' };
+};
+```
+
+## Xem thêm
+- [Process Model Documentation](https://www.electronjs.org/docs/latest/tutorial/process-model)
+- [Context Isolation Documentation](https://www.electronjs.org/docs/latest/tutorial/context-isolation)
+- [Inter-Process Communication Documentation](https://www.electronjs.org/docs/latest/tutorial/ipc)
+- [Example](https://github.com/feature-sliced/examples/tree/master/examples/electron)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/with-nextjs.mdx
@@ -1,0 +1,197 @@
+---
+sidebar_position: 1
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Sử dụng với Next.js
+
+FSD tương thích với Next.js trong cả phiên bản App Router và Pages Router nếu bạn giải quyết được xung đột chính — thư mục `app` và `pages`.
+
+## App Router {#app-router}
+
+### Xung đột giữa FSD và Next.js trong layer `app` {#conflict-between-fsd-and-nextjs-in-the-app-layer}
+
+Next.js đề xuất sử dụng thư mục `app` để định nghĩa các route của ứng dụng. Nó mong đợi các file trong thư mục `app` tương ứng với các pathname. Cơ chế routing này **không phù hợp** với khái niệm FSD, vì không thể duy trì cấu trúc slice phẳng.
+
+Giải pháp là di chuyển thư mục `app` của Next.js vào thư mục gốc của dự án và import các pages FSD từ `src`, nơi chứa các layer FSD, vào thư mục `app` của Next.js.
+
+Bạn cũng cần thêm thư mục `pages` vào thư mục gốc của dự án, nếu không Next.js sẽ cố gắng sử dụng `src/pages` như Pages Router ngay cả khi bạn sử dụng App Router, điều này sẽ làm hỏng quá trình build. Cũng nên đặt file `README.md` bên trong thư mục `pages` gốc này để mô tả tại sao nó cần thiết, mặc dù nó trống.
+
+```sh
+├── app                              # App folder (Next.js)
+│   ├── api
+│   │   └── get-example
+│   │       └── route.ts
+│   └── example
+│       └── page.tsx
+├── pages                            # Empty pages folder (Next.js)
+│   └── README.md
+└── src
+    ├── app
+    │   └── api-routes               # API routes
+    ├── pages
+    │   └── example
+    │       ├── index.ts
+    │       └── ui
+    │           └── example.tsx
+    ├── widgets
+    ├── features
+    ├── entities
+    └── shared
+```
+
+Ví dụ về việc re-export một page từ `src/pages` trong `app` của Next.js:
+
+```tsx title="app/example/page.tsx"
+export { ExamplePage as default, metadata } from '@/pages/example';
+```
+
+### Middleware {#middleware}
+
+Nếu bạn sử dụng middleware trong dự án, nó phải được đặt ở thư mục gốc của dự án cùng với thư mục `app` và `pages` của Next.js.
+
+### Instrumentation {#instrumentation}
+
+File `instrumentation.js` cho phép bạn giám sát hiệu suất và hành vi của ứng dụng. Nếu bạn sử dụng nó, nó phải được đặt ở thư mục gốc của dự án, tương tự như `middleware.js`.
+
+## Pages Router {#pages-router}
+
+### Xung đột giữa FSD và Next.js trong layer `pages` {#conflict-between-fsd-and-nextjs-in-the-pages-layer}
+
+Các route nên được đặt trong thư mục `pages` ở thư mục gốc của dự án, tương tự như thư mục `app` cho App Router. Cấu trúc bên trong `src` nơi các thư mục layer được đặt vẫn không thay đổi.
+
+```sh
+├── pages                            # Pages folder (Next.js)
+│   ├── _app.tsx
+│   ├── api
+│   │   └── example.ts               # API route re-export
+│   └── example
+│       └── index.tsx
+└── src
+    ├── app
+    │   ├── custom-app
+    │   │   └── custom-app.tsx       # Custom App component
+    │   └── api-routes
+    │       └── get-example-data.ts  # API route
+    ├── pages
+    │   └── example
+    │       ├── index.ts
+    │       └── ui
+    │           └── example.tsx
+    ├── widgets
+    ├── features
+    ├── entities
+    └── shared
+```
+
+Ví dụ về việc re-export một page từ `src/pages` trong `pages` của Next.js:
+
+```tsx title="pages/example/index.tsx"
+export { Example as default } from '@/pages/example';
+```
+
+### Custom `_app` component {#custom-_app-component}
+
+Bạn có thể đặt Custom App component của mình trong `src/app/_app` hoặc `src/app/custom-app`:
+
+```tsx title="src/app/custom-app/custom-app.tsx"
+import type { AppProps } from 'next/app';
+
+export const MyApp = ({ Component, pageProps }: AppProps) => {
+    return (
+        <>
+            <p>My Custom App component</p>
+            <Component { ...pageProps } />
+        </>
+    );
+};
+```
+
+```tsx title="pages/_app.tsx"
+export { App as default } from '@/app/custom-app';
+```
+
+## Route Handlers (API routes) {#route-handlers-api-routes}
+
+Sử dụng segment `api-routes` trong layer `app` để làm việc với Route Handlers.
+
+Hãy chú ý khi viết code backend trong cấu trúc FSD — FSD chủ yếu dành cho frontend, nghĩa là đó là điều mà mọi người sẽ mong đợi tìm thấy.
+Nếu bạn cần nhiều endpoint, hãy cân nhắc tách chúng thành một package khác trong một monorepo.
+
+<Tabs>
+
+<TabItem value="app-router" label="App Router">
+
+```tsx title="src/app/api-routes/get-example-data.ts"
+import { getExamplesList } from '@/shared/db';
+
+export const getExampleData = () => {
+    try {
+        const examplesList = getExamplesList();
+
+        return Response.json({ examplesList });
+    } catch {
+        return Response.json(null, {
+            status: 500,
+            statusText: 'Ouch, something went wrong',
+        });
+    }
+};
+```
+
+```tsx title="app/api/example/route.ts"
+export { getExampleData as GET } from '@/app/api-routes';
+```
+
+</TabItem>
+
+<TabItem value="pages-router" label="Pages Router">
+
+```tsx title="src/app/api-routes/get-example-data.ts"
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const config = {
+    api: {
+        bodyParser: {
+            sizeLimit: '1mb',
+        },
+    },
+    maxDuration: 5,
+};
+
+const handler = (req: NextApiRequest, res: NextApiResponse<ResponseData>) => {
+    res.status(200).json({ message: 'Hello from FSD' });
+};
+
+export const getExampleData = { config, handler } as const;
+```
+
+```tsx title="src/app/api-routes/index.ts"
+export { getExampleData } from './get-example-data';
+```
+
+```tsx title="app/api/example.ts"
+import { getExampleData } from '@/app/api-routes';
+
+export const config = getExampleData.config;
+export default getExampleData.handler;
+```
+
+</TabItem>
+
+</Tabs>
+
+## Các đề xuất bổ sung {#additional-recommendations}
+
+- Sử dụng segment `db` trong layer `shared` để mô tả các database query và việc sử dụng chúng ở các layer cao hơn.
+- Logic caching và revalidating queries tốt nhất nên được giữ cùng chỗ với các query.
+
+## Xem thêm {#see-also}
+
+- [Next.js Project Structure](https://nextjs.org/docs/app/getting-started/project-structure)
+- [Next.js Page Layouts](https://nextjs.org/docs/app/getting-started/layouts-and-pages)
+
+[project-knowledge]: /docs/about/understanding/knowledge-types
+[ext-app-router-stackblitz]: https://stackblitz.com/edit/stackblitz-starters-aiez55?file=README.md

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/with-nuxtjs.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/with-nuxtjs.mdx
@@ -1,0 +1,179 @@
+---
+sidebar_position: 10
+---
+# Sử dụng với NuxtJS
+
+Có thể triển khai FSD trong dự án NuxtJS, nhưng xảy ra xung đột do sự khác biệt giữa yêu cầu cấu trúc dự án của NuxtJS và các nguyên tắc FSD:
+
+- Ban đầu, NuxtJS cung cấp cấu trúc file dự án không có thư mục `src`, tức là ở thư mục gốc của dự án.
+- File routing nằm trong thư mục `pages`, trong khi ở FSD thư mục này được dành riêng cho cấu trúc slice phẳng.
+
+
+## Thêm alias cho thư mục `src`
+
+Thêm đối tượng `alias` vào config của bạn:
+```ts title="nuxt.config.ts"
+export default defineNuxtConfig({
+  devtools: { enabled: true }, // Not FSD related, enabled at project startup
+  alias: {
+    "@": '../src'
+  },
+})
+```
+## Chọn cách cấu hình router
+
+Trong NuxtJS, có hai cách để tùy chỉnh routing - sử dụng config và sử dụng cấu trúc file.
+Trong trường hợp file-based routing, bạn sẽ tạo các file index.vue trong các thư mục bên trong thư mục app/routes, và trong trường hợp configure, bạn sẽ cấu hình các router trong file `router.options.ts`.
+
+
+### Routing sử dụng config
+
+Trong layer `app`, tạo file `router.options.ts` và export một config object từ nó:
+```ts title="app/router.options.ts"
+import type { RouterConfig } from '@nuxt/schema';
+
+export default <RouterConfig> {
+  routes: (_routes) => [],
+};
+
+```
+
+Để thêm page `Home` vào dự án của bạn, bạn cần thực hiện các bước sau:
+- Thêm một page slice bên trong layer `pages`
+- Thêm route phù hợp vào config `app/router.config.ts`
+
+
+Để tạo một page slice, hãy sử dụng [CLI](https://github.com/feature-sliced/cli):
+
+```shell
+fsd pages home
+```
+
+Tạo file ``home-page.vue`` bên trong segment ui, truy cập nó bằng Public API
+
+```ts title="src/pages/home/index.ts"
+export { default as HomePage } from './ui/home-page';
+```
+
+Vậy, cấu trúc file sẽ trông như thế này:
+```sh
+|── src
+│   ├── app
+│   │   ├── router.config.ts
+│   ├── pages
+│   │   ├── home
+│   │   │   ├── ui
+│   │   │   │   ├── home-page.vue
+│   │   │   ├── index.ts
+```
+Cuối cùng, hãy thêm một route vào config:
+
+```ts title="app/router.config.ts"
+import type { RouterConfig } from '@nuxt/schema'
+
+export default <RouterConfig> {
+  routes: (_routes) => [
+    {
+      name: 'home',
+      path: '/',
+      component: () => import('@/pages/home.vue').then(r => r.default || r)
+    }
+  ],
+}
+```
+
+### File Routing
+
+Trước tiên, tạo thư mục `src` trong thư mục gốc của dự án của bạn, và tạo các layer app và pages bên trong thư mục này cùng với thư mục routes bên trong layer app.
+Vậy, cấu trúc file của bạn nên trông như thế này:
+
+```sh
+├── src
+│   ├── app
+│   │   ├── routes
+│   ├── pages                         # Pages folder, related to FSD
+```
+
+Để NuxtJS sử dụng thư mục routes bên trong layer `app` cho file routing, bạn cần sửa đổi `nuxt.config.ts` như sau:
+```ts title="nuxt.config.ts"
+export default defineNuxtConfig({
+  devtools: { enabled: true }, // Not FSD related, enabled at project startup
+  alias: {
+    "@": '../src'
+  },
+  dir: {
+    pages: './src/app/routes'
+  }
+})
+```
+
+Bây giờ, bạn có thể tạo các route cho pages trong `app` và kết nối các page từ `pages` với chúng.
+
+Ví dụ, để thêm page `Home` vào dự án của bạn, bạn cần thực hiện các bước sau:
+- Thêm một page slice bên trong layer `pages`
+- Thêm route tương ứng bên trong layer `app`
+- Kết nối page từ slice với route
+
+Để tạo một page slice, hãy sử dụng [CLI](https://github.com/feature-sliced/cli):
+
+```shell
+fsd pages home
+```
+
+Tạo file ``home-page.vue`` bên trong segment ui, truy cập nó bằng Public API
+
+```ts title="src/pages/home/index.ts"
+export { default as HomePage } from './ui/home-page';
+```
+
+Tạo một route cho page này bên trong layer `app`:
+
+```sh
+
+├── src
+│   ├── app
+│   │   ├── routes
+│   │   │   ├── index.vue
+│   ├── pages
+│   │   ├── home
+│   │   │   ├── ui
+│   │   │   │   ├── home-page.vue
+│   │   │   ├── index.ts
+```
+
+Thêm page component của bạn vào bên trong file `index.vue`:
+
+```html title="src/app/routes/index.vue"
+<script setup>
+  import { HomePage } from '@/pages/home';
+</script>
+
+<template>
+  <HomePage/>
+</template>
+```
+
+## Làm gì với `layouts`?
+
+Bạn có thể đặt layouts bên trong layer `app`, để làm điều này bạn cần sửa đổi config như sau:
+
+```ts title="nuxt.config.ts"
+export default defineNuxtConfig({
+  devtools: { enabled: true }, // Not related to FSD, enabled at project startup
+  alias: {
+    "@": '../src'
+  },
+  dir: {
+    pages: './src/app/routes',
+    layouts: './src/app/layouts'
+  }
+})
+```
+
+
+## Xem thêm
+
+- [Documentation on changing directory config in NuxtJS](https://nuxt.com/docs/api/nuxt-config#dir)
+- [Documentation on changing router config in NuxtJS](https://nuxt.com/docs/guide/recipes/custom-routing#router-config)
+- [Documentation on changing aliases in NuxtJS](https://nuxt.com/docs/api/nuxt-config#alias)
+

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/with-react-query.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/with-react-query.mdx
@@ -1,0 +1,436 @@
+---
+sidebar_position: 10
+---
+# Sử dụng với React Query
+
+## Vấn đề "nên đặt các key ở đâu"
+
+### Giải pháp — phân chia theo entities
+
+Nếu dự án đã có sự phân chia thành các entity, và mỗi request tương ứng với một entity duy nhất,
+cách phân chia thuần khiết nhất sẽ là theo entity. Trong trường hợp này, chúng tôi đề xuất sử dụng cấu trúc sau:
+```sh
+└── src/                                        #
+    ├── app/                                    #
+    |   ...                                     #
+    ├── pages/                                  #
+    |   ...                                     #
+    ├── entities/                               #
+    |     ├── {entity}/                         #
+    |    ...     └── api/                       #
+    |                 ├── `{entity}.query`      # Query-factory where are the keys and functions
+    |                 ├── `get-{entity}`        # Entity getter function
+    |                 ├── `create-{entity}`     # Entity creation function
+    |                 ├── `update-{entity}`     # Entity update function
+    |                 ├── `delete-{entity}`     # Entity delete function
+    |                ...                        #
+    |                                           #
+    ├── features/                               #
+    |   ...                                     #
+    ├── widgets/                                #
+    |   ...                                     #
+    └── shared/                                 #
+        ...                                     #
+```
+
+Nếu có kết nối giữa các entity (ví dụ, entity Country có field-list của các entity City),
+thì bạn có thể sử dụng [public API for cross-imports][public-api-for-cross-imports] hoặc cân nhắc giải pháp thay thế bên dưới.
+
+### Giải pháp thay thế — giữ trong shared
+
+Trong các trường hợp mà việc tách biệt entity không phù hợp, có thể cân nhắc cấu trúc sau:
+
+```sh
+└── src/                                        #
+   ...                                          #
+    └── shared/                                 #
+          ├── api/                              #
+         ...   ├── `queries`                    # Query-factories
+               |      ├── `document.ts`         #
+               |      ├── `background-jobs.ts`  #
+               |     ...                        #
+               └──  index.ts                    #
+```
+
+Sau đó trong `@/shared/api/index.ts`:
+
+```ts title="@/shared/api/index.ts"
+export { documentQueries } from "./queries/document";
+```
+
+## Vấn đề "Đặt mutations ở đâu?"
+
+Không nên trộn lẫn mutations với queries. Có hai lựa chọn:
+
+### 1. Định nghĩa một custom hook trong segment `api` gần nơi sử dụng
+
+```tsx title="@/features/update-post/api/use-update-title.ts"
+export const useUpdateTitle = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, newTitle }) =>
+      apiClient
+        .patch(`/posts/${id}`, { title: newTitle })
+        .then((data) => console.log(data)),
+
+    onSuccess: (newPost) => {
+      queryClient.setQueryData(postsQueries.ids(id), newPost);
+    },
+  });
+};
+```
+
+### 2. Định nghĩa một mutation function ở nơi khác (Shared hoặc Entities) và sử dụng `useMutation` trực tiếp trong component
+
+```tsx
+const { mutateAsync, isPending } = useMutation({
+  mutationFn: postApi.createPost,
+});
+```
+
+```tsx title="@/pages/post-create/ui/post-create-page.tsx"
+export const CreatePost = () => {
+  const { classes } = useStyles();
+  const [title, setTitle] = useState("");
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: postApi.createPost,
+  });
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) =>
+    setTitle(e.target.value);
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    mutate({ title, userId: DEFAULT_USER_ID });
+  };
+
+  return (
+    <form className={classes.create_form} onSubmit={handleSubmit}>
+      <TextField onChange={handleChange} value={title} />
+      <LoadingButton type="submit" variant="contained" loading={isPending}>
+        Create
+      </LoadingButton>
+    </form>
+  );
+};
+```
+
+## Tổ chức các request
+
+### Query factory
+
+Một query factory là một object mà các giá trị key là các function trả về một danh sách các query key. Đây là cách sử dụng nó:
+
+```ts
+const keyFactory = {
+  all: () => ["entity"],
+  lists: () => [...postQueries.all(), "list"],
+};
+```
+
+:::info
+`queryOptions` is a built-in utility in react-query@v5 (optional)
+
+```ts
+queryOptions({
+  queryKey,
+  ...options,
+});
+```
+
+For greater type safety, further compatibility with future versions of react-query, and easy access to functions and query keys,
+you can use the built-in queryOptions function from “@tanstack/react-query”
+[(More details here)](https://tkdodo.eu/blog/the-query-options-api#queryoptions).
+:::
+
+### 1. Tạo một Query Factory
+
+```tsx title="@/entities/post/api/post.queries.ts"
+import { keepPreviousData, queryOptions } from "@tanstack/react-query";
+import { getPosts } from "./get-posts";
+import { getDetailPost } from "./get-detail-post";
+import { PostDetailQuery } from "./query/post.query";
+
+export const postQueries = {
+  all: () => ["posts"],
+
+  lists: () => [...postQueries.all(), "list"],
+  list: (page: number, limit: number) =>
+    queryOptions({
+      queryKey: [...postQueries.lists(), page, limit],
+      queryFn: () => getPosts(page, limit),
+      placeholderData: keepPreviousData,
+    }),
+
+  details: () => [...postQueries.all(), "detail"],
+  detail: (query?: PostDetailQuery) =>
+    queryOptions({
+      queryKey: [...postQueries.details(), query?.id],
+      queryFn: () => getDetailPost({ id: query?.id }),
+      staleTime: 5000,
+    }),
+};
+```
+
+### 2. Sử dụng Query Factory trong code ứng dụng
+```tsx
+import { useParams } from "react-router-dom";
+import { postApi } from "@/entities/post";
+import { useQuery } from "@tanstack/react-query";
+
+type Params = {
+  postId: string;
+};
+
+export const PostPage = () => {
+  const { postId } = useParams<Params>();
+  const id = parseInt(postId || "");
+  const {
+    data: post,
+    error,
+    isLoading,
+    isError,
+  } = useQuery(postApi.postQueries.detail({ id }));
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (isError || !post) {
+    return <>{error?.message}</>;
+  }
+
+  return (
+    <div>
+      <p>Post id: {post.id}</p>
+      <div>
+        <h1>{post.title}</h1>
+        <div>
+          <p>{post.body}</p>
+        </div>
+      </div>
+      <div>Owner: {post.userId}</div>
+    </div>
+  );
+};
+```
+
+### Lợi ích của việc sử dụng Query Factory
+- **Request structuring:** A factory allows you to organize all API requests in one place, making your code more readable and maintainable.
+- **Convenient access to queries and keys:** The factory provides convenient methods for accessing different types of queries and their keys.
+- **Query Refetching Ability:** The factory allows easy refetching without the need to change query keys in different parts of the application.
+
+## Phân trang
+
+In this section, we'll look at an example of the `getPosts` function, which makes an API request to retrieve post entities using pagination.
+
+### 1. Tạo function `getPosts`
+The getPosts function is located in the `get-posts.ts` file, which is located in the `api` segment
+
+```tsx title="@/pages/post-feed/api/get-posts.ts"
+import { apiClient } from "@/shared/api/base";
+
+import { PostWithPaginationDto } from "./dto/post-with-pagination.dto";
+import { PostQuery } from "./query/post.query";
+import { mapPost } from "./mapper/map-post";
+import { PostWithPagination } from "../model/post-with-pagination";
+
+const calculatePostPage = (totalCount: number, limit: number) =>
+  Math.floor(totalCount / limit);
+
+export const getPosts = async (
+  page: number,
+  limit: number,
+): Promise<PostWithPagination> => {
+  const skip = page * limit;
+  const query: PostQuery = { skip, limit };
+  const result = await apiClient.get<PostWithPaginationDto>("/posts", query);
+
+  return {
+    posts: result.posts.map((post) => mapPost(post)),
+    limit: result.limit,
+    skip: result.skip,
+    total: result.total,
+    totalPages: calculatePostPage(result.total, limit),
+  };
+};
+```
+
+### 2. Query factory cho phân trang
+The `postQueries` query factory defines various query options for working with posts,
+including requesting a list of posts with a specific page and limit.
+
+```tsx
+import { keepPreviousData, queryOptions } from "@tanstack/react-query";
+import { getPosts } from "./get-posts";
+
+export const postQueries = {
+  all: () => ["posts"],
+  lists: () => [...postQueries.all(), "list"],
+  list: (page: number, limit: number) =>
+    queryOptions({
+      queryKey: [...postQueries.lists(), page, limit],
+      queryFn: () => getPosts(page, limit),
+      placeholderData: keepPreviousData,
+    }),
+};
+```
+
+
+### 3. Sử dụng trong code ứng dụng
+
+```tsx title="@/pages/home/ui/index.tsx"
+export const HomePage = () => {
+  const itemsOnScreen = DEFAULT_ITEMS_ON_SCREEN;
+  const [page, setPage] = usePageParam(DEFAULT_PAGE);
+  const { data, isFetching, isLoading } = useQuery(
+    postApi.postQueries.list(page, itemsOnScreen),
+  );
+  return (
+    <>
+      <Pagination
+        onChange={(_, page) => setPage(page)}
+        page={page}
+        count={data?.totalPages}
+        variant="outlined"
+        color="primary"
+      />
+      <Posts posts={data?.posts} />
+    </>
+  );
+};
+```
+:::note
+The example is simplified, the full version is available on [GitHub](https://github.com/ruslan4432013/fsd-react-query-example)
+:::
+
+## `QueryProvider` để quản lý queries
+In this guide, we will look at how to organize a `QueryProvider`.
+
+### 1. Tạo một `QueryProvider`
+The file `query-provider.tsx` is located at the path `@/app/providers/query-provider.tsx`.
+
+```tsx title="@/app/providers/query-provider.tsx"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  client: QueryClient;
+};
+
+export const QueryProvider = ({ client, children }: Props) => {
+  return (
+    <QueryClientProvider client={client}>
+      {children}
+      <ReactQueryDevtools />
+    </QueryClientProvider>
+  );
+};
+```
+
+### 2. Tạo một `QueryClient`
+`QueryClient` is an instance used to manage API requests.
+The `query-client.ts` file is located at `@/shared/api/query-client.ts`.
+`QueryClient` is created with certain settings for query caching.
+
+```tsx title="@/shared/api/query-client.ts"
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      gcTime: 5 * 60 * 1000,
+    },
+  },
+});
+```
+
+## Tự động sinh code
+
+There are tools that can generate API code for you, but they are less flexible than the manual approach described above.
+If your Swagger file is well-structured,
+and you're using one of these tools, it might make sense to generate all the code in the `@/shared/api` directory.
+
+
+## Lời khuyên bổ sung cho việc tổ chức RQ
+### API Client
+
+Using a custom API client class in the shared layer,
+you can standardize the configuration and work with the API in the project.
+This allows you to manage logging,
+headers and data exchange format (such as JSON or XML) from one place.
+This approach makes it easier to maintain and develop the project because it simplifies changes and updates to interactions with the API.
+
+```tsx title="@/shared/api/api-client.ts"
+import { API_URL } from "@/shared/config";
+
+export class ApiClient {
+  private baseUrl: string;
+
+  constructor(url: string) {
+    this.baseUrl = url;
+  }
+
+  async handleResponse<TResult>(response: Response): Promise<TResult> {
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    try {
+      return await response.json();
+    } catch (error) {
+      throw new Error("Error parsing JSON response");
+    }
+  }
+
+  public async get<TResult = unknown>(
+    endpoint: string,
+    queryParams?: Record<string, string | number>,
+  ): Promise<TResult> {
+    const url = new URL(endpoint, this.baseUrl);
+
+    if (queryParams) {
+      Object.entries(queryParams).forEach(([key, value]) => {
+        url.searchParams.append(key, value.toString());
+      });
+    }
+    const response = await fetch(url.toString(), {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    return this.handleResponse<TResult>(response);
+  }
+
+  public async post<TResult = unknown, TData = Record<string, unknown>>(
+    endpoint: string,
+    body: TData,
+  ): Promise<TResult> {
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    return this.handleResponse<TResult>(response);
+  }
+}
+
+export const apiClient = new ApiClient(API_URL);
+```
+
+## Xem thêm {#see-also}
+
+- [(GitHub) Sample Project](https://github.com/ruslan4432013/fsd-react-query-example)
+- [(CodeSandbox) Sample Project](https://codesandbox.io/p/github/ruslan4432013/fsd-react-query-example/main)
+- [About the query factory](https://tkdodo.eu/blog/the-query-options-api)
+
+[public-api-for-cross-imports]: /docs/reference/public-api#public-api-for-cross-imports

--- a/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/with-sveltekit.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/guides/tech/with-sveltekit.mdx
@@ -1,0 +1,100 @@
+---
+sidebar_position: 10
+---
+# Sử dụng với SvelteKit
+
+Có thể triển khai FSD trong dự án SvelteKit, nhưng xảy ra xung đột do sự khác biệt giữa yêu cầu cấu trúc của dự án SvelteKit và các nguyên tắc của FSD:
+
+- Ban đầu, SvelteKit cung cấp cấu trúc file bên trong thư mục `src/routes`, trong khi ở FSD thì routing phải là một phần của layer `app`.
+- SvelteKit đề xuất đặt mọi thứ không liên quan đến routing trong thư mục `src/lib`.
+
+
+## Hãy thiết lập config
+
+```ts title="svelte.config.ts"
+import adapter from '@sveltejs/adapter-auto';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config}*/
+const config = {
+  preprocess: [vitePreprocess()],
+  kit: {
+    adapter: adapter(),
+    files: {
+      routes: 'src/app/routes',             // move routing inside the app layer
+      lib: 'src',
+      appTemplate: 'src/app/index.html',    // Move the application entry point inside the app layer
+      assets: 'public'
+    },
+    alias: {
+      '@/*': 'src/*'                        // Create an alias for the src directory
+    }
+  }
+};
+export default config;
+```
+
+## Di chuyển file routing vào `src/app`.
+
+Hãy tạo một layer app, di chuyển điểm đầu vào `index.html` của app vào đó, và tạo một thư mục routes.
+Vậy, cấu trúc file của bạn nên trông như thế này:
+
+```sh
+├── src
+│   ├── app
+│   │   ├── index.html
+│   │   ├── routes
+│   ├── pages                               # FSD Pages folder
+```
+
+Bây giờ, bạn có thể tạo các route cho pages trong `app` và kết nối các page từ `pages` với chúng.
+
+Ví dụ, để thêm một home page vào dự án của bạn, bạn cần thực hiện các bước sau:
+- Thêm một page slice bên trong layer `pages`
+- Thêm route tương ứng vào thư mục `routes` từ layer `app`
+- Canh chỉnh page từ slice với route
+
+Để tạo một page slice, hãy sử dụng [CLI](https://github.com/feature-sliced/cli):
+
+```shell
+fsd pages home
+```
+
+Tạo file ``home-page.svelte`` bên trong segment ui, truy cập nó bằng Public API
+
+```ts title="src/pages/home/index.ts"
+export { default as HomePage } from './ui/home-page.svelte';
+```
+
+Tạo một route cho page này bên trong layer `app`:
+
+```sh
+
+├── src
+│   ├── app
+│   │   ├── routes
+│   │   │   ├── +page.svelte
+│   │   ├── index.html
+│   ├── pages
+│   │   ├── home
+│   │   │   ├── ui
+│   │   │   │   ├── home-page.svelte
+│   │   │   ├── index.ts
+```
+
+Thêm page component của bạn vào bên trong file `+page.svelte`:
+
+```html title="src/app/routes/+page.svelte"
+<script>
+  import { HomePage } from '@/pages/home';
+</script>
+
+
+<HomePage/>
+```
+
+## Xem thêm
+
+- [Documentation on changing directory config in SvelteKit](https://kit.svelte.dev/docs/configuration#files)
+
+

--- a/i18n/vi/docusaurus-plugin-content-docs/current/llms.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/llms.mdx
@@ -1,0 +1,23 @@
+---
+id: llms
+title: Tài liệu cho LLMs
+slug: llms
+sidebar_label: Tài liệu cho LLMs
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+Trang này cung cấp các liên kết và hướng dẫn cho các LLM crawler.
+
+- Spec: https://llmstxt.org/
+
+### Files
+
+- <a href={useBaseUrl('llms.txt')}>llms.txt</a>
+- <a href={useBaseUrl('llms-full.txt')}>llms-full.txt</a>
+
+### Ghi chú
+
+- Các file được phục vụ từ root của site, bất kể đường dẫn trang hiện tại.
+- Trong các triển khai có base URL không phải root (ví dụ `/documentation/`), các liên kết phía trên sẽ được tự động thêm prefix.
+

--- a/i18n/vi/docusaurus-plugin-content-docs/current/reference/layers.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/reference/layers.mdx
@@ -1,0 +1,154 @@
+---
+sidebar_position: 1
+pagination_next: reference/slices-segments
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+# Layer
+
+Layer là cấp độ đầu tiên của hệ thống phân cấp tổ chức trong Feature-Sliced Design. Mục đích của chúng là phân tách code dựa trên mức độ trách nhiệm cần thiết và số lượng module khác trong app mà nó phụ thuộc vào. Mỗi layer mang ý nghĩa ngữ nghĩa đặc biệt để giúp bạn xác định mức độ trách nhiệm mà bạn nên phân bổ cho code của mình.
+
+Có tổng cộng **7 layer**, được sắp xếp từ nhiều trách nhiệm và&nbsp;dependency nhất đến ít nhất:
+
+<img src={useBaseUrl("/img/layers/folders-graphic-light.svg#light-mode-only")} width="180" style={{ float: "right", margin: "0 1em" }} alt="A file system tree, with a single root folder called src and then seven subfolders: app, processes, pages, widgets, features, entities, shared. The processes folder is slightly faded out." />
+<img src={useBaseUrl("/img/layers/folders-graphic-dark.svg#dark-mode-only")} width="180" style={{ float: "right", margin: "0 1em" }} alt="A file system tree, with a single root folder called src and then seven subfolders: app, processes, pages, widgets, features, entities, shared. The processes folder is slightly faded out." />
+
+1. App
+2. Processes (deprecated)
+3. Pages
+4. Widgets
+5. Features
+6. Entities
+7. Shared
+
+Bạn không cần phải sử dụng mọi layer trong dự án của mình — chỉ thêm chúng nếu bạn nghĩ nó mang lại giá trị cho dự án của bạn. Thông thường, hầu hết các dự án frontend sẽ có ít nhất các layer Shared, Pages và App.
+
+Trong thực tế, layer là các folder với tên viết thường (ví dụ: `📁 shared`, `📁 pages`, `📁 app`). Việc thêm layer mới _không được khuyến nghị_ vì ngữ nghĩa của chúng đã được chuẩn hóa.
+
+## Import rule trên layer
+
+Layer được tạo thành từ các _slice_ — các nhóm module có tính gắn kết cao. Dependency giữa các slice được điều chỉnh bởi **import rule trên layer**:
+
+> _Một module (file) trong slice chỉ có thể import các slice khác khi chúng nằm trên các layer thấp hơn một cách nghiêm ngặt._
+
+Ví dụ, folder `📁 ~/features/aaa` là một slice với tên "aaa". Một file bên trong nó, `~/features/aaa/api/request.ts`, không thể import code từ bất kỳ file nào trong `📁 ~/features/bbb`, nhưng có thể import code từ `📁 ~/entities` và `📁 ~/shared`, cũng như bất kỳ code anh em nào từ `📁 ~/features/aaa`, ví dụ `~/features/aaa/lib/cache.ts`.
+
+Layer App và Shared là **ngoại lệ** của quy tắc này — chúng vừa là layer vừa là slice cùng một lúc. Slice phân chia code theo business domain, và hai layer này là ngoại lệ vì Shared không có business domain, và App kết hợp tất cả business domain.
+
+Trong thực tế, điều này có nghĩa là layer App và Shared được tạo thành từ các segment, và các segment có thể import lẫn nhau một cách tự do.
+
+## Định nghĩa layer
+
+Phần này mô tả ý nghĩa ngữ nghĩa của từng layer để tạo ra trực giác về loại code nào thuộc về đó.
+
+### Shared
+
+Layer này tạo thành nền tảng cho phần còn lại của app. Đây là nơi tạo kết nối với thế giới bên ngoài, ví dụ: backend, third-party library, environment. Đây cũng là nơi định nghĩa các library có tính chứa đựng cao của riêng bạn.
+
+Layer này, giống như layer App, _không chứa slice_. Slice được dùng để chia layer thành các business domain, nhưng business domain không tồn tại trong Shared. Điều này có nghĩa là tất cả file trong Shared có thể tham chiếu và import lẫn nhau.
+
+Dưới đây là các segment mà bạn thường có thể tìm thấy trong layer này:
+
+- `📁 api` — API client và có thể cả các function để thực hiện request đến các endpoint backend cụ thể.
+- `📁 ui` — bộ UI kit của ứng dụng.  
+  Các component trên layer này không nên chứa business logic, nhưng có thể có chủ đề business. Ví dụ, bạn có thể đặt logo công ty và layout trang ở đây. Các component có UI logic cũng được cho phép (ví dụ: autocomplete hoặc search bar).
+- `📁 lib` — tập hợp các internal library.  
+  Folder này không nên được coi như helper hoặc utility ([đọc ở đây tại sao những folder này thường trở thành bãi rác][ext-sova-utility-dump]). Thay vào đó, mỗi library trong folder này nên có một lĩnh vực tập trung, ví dụ: date, color, text manipulation, v.v. Lĩnh vực tập trung đó nên được ghi lại trong file README. Các developer trong team của bạn nên biết có thể thêm gì và không thể thêm gì vào những library này.
+- `📁 config` — environment variable, global feature flag và các cấu hình global khác cho app của bạn.
+- `📁 routes` — route constant hoặc pattern để matching route.
+- `📁 i18n` — setup code cho translation, global translation string.
+
+Bạn được tự do thêm nhiều segment hơn, nhưng hãy đảm bảo rằng tên của những segment này mô tả mục đích của nội dung, không phải bản chất của nó. Ví dụ, `components`, `hooks`, và `types` là những tên segment tệ vì chúng không hữu ích khi bạn đang tìm kiếm code.
+
+### Entities
+
+Các slice trên layer này đại diện cho các khái niệm từ thế giới thực mà dự án đang làm việc. Thông thường, chúng là các thuật ngữ mà business sử dụng để mô tả sản phẩm. Ví dụ, một mạng xã hội có thể làm việc với các business entity như User, Post và Group.
+
+Một entity slice có thể chứa data storage (`📁 model`), data validation schema (`📁 model`), các function API request liên quan đến entity (`📁 api`), cũng như visual representation của entity này trong interface (`📁 ui`). Visual representation không cần phải tạo ra một UI block hoàn chỉnh — nó chủ yếu nhằm tái sử dụng cùng một appearance trên nhiều page trong app, và các business logic khác nhau có thể được gắn vào nó thông qua props hoặc slot.
+
+#### Mối quan hệ entity
+
+Entity trong FSD là các slice, và mặc định, các slice không thể biết về nhau. Tuy nhiên, trong đời thực, các entity thường tương tác với nhau, và đôi khi một entity sở hữu hoặc chứa các entity khác. Vì vậy, business logic của những tương tác này tốt nhất nên được giữ ở các layer cao hơn, như Features hoặc Pages.
+
+Khi data object của một entity chứa các data object khác, thường là ý tưởng tốt để làm cho kết nối giữa các entity trở nên rõ ràng và bỏ qua slice isolation bằng cách tạo cross-reference API với ký hiệu `@x`. Lý do là các entity được kết nối cần được refactor cùng nhau, vì vậy tốt nhất là làm cho kết nối không thể bỏ sót.
+
+For example:
+
+```ts title="entities/artist/model/artist.ts"
+import type { Song } from "entities/song/@x/artist";
+
+export interface Artist {
+  name: string;
+  songs: Array<Song>;
+}
+```
+
+```ts title="entities/song/@x/artist.ts"
+export type { Song } from "../model/song.ts";
+```
+
+Tìm hiểu thêm về ký hiệu `@x` trong phần [Public API cho cross-import][public-api-for-cross-imports].
+
+### Features
+
+Layer này dành cho các tương tác chính trong app của bạn, những thứ mà người dùng quan tâm để làm. Các tương tác này thường liên quan đến các business entity, vì đó là nội dung của app.
+
+Một nguyên tắc quan trọng để sử dụng layer Features hiệu quả là: **không phải mọi thứ đều cần là feature**. Một chỉ báo tốt để biết thứ gì cần là feature là nó được tái sử dụng trên nhiều page.
+
+Ví dụ, nếu app có nhiều editor, và tất cả chúng đều có comment, thì comment là một feature được tái sử dụng. Hãy nhớ rằng slice là cơ chế để tìm code nhanh chóng, và nếu có quá nhiều feature, những cái quan trọng sẽ bị chìm nghỉm.
+
+Lý tưởng, khi bạn đến một dự án mới, bạn sẽ khám phá tính năng của nó bằng cách xem qua các page và feature. Khi quyết định thứ gì nên là feature, hãy tối ưu hóa cho trải nghiệm của người mới vào dự án để nhanh chóng khám phá các khu vực code lớn quan trọng.
+
+Một feature slice có thể chứa UI để thực hiện tương tác như form (`📁 ui`), các API call cần thiết để thực hiện action (`📁 api`), validation và internal state (`📁 model`), feature flag (`📁 config`).
+
+### Widgets
+
+Layer Widgets được thiết kế cho các UI block lớn tự đủ. Widget hữu ích nhất khi chúng được tái sử dụng trên nhiều page, hoặc khi page mà chúng thuộc về có nhiều block độc lập lớn, và đây là một trong số chúng.
+
+Nếu một UI block tạo nên phần lớn nội dung thú vị trên page, và không bao giờ được tái sử dụng, nó **không nên là widget**, và thay vào đó nên được đặt trực tiếp bên trong page đó.
+
+:::tip
+
+Nếu bạn đang sử dụng nested routing system (như router của [Remix][ext-remix]), có thể hữu ích khi sử dụng layer Widgets giống như cách mà flat routing system sẽ sử dụng layer Pages — để tạo các router block đầy đủ, hoàn chỉnh với data fetching liên quan, loading state, và error boundary.
+
+Tương tự, bạn có thể lưu page layout trên layer này.
+
+:::
+
+### Pages
+
+Page là thứ tạo nên các website và application (cũng được biết đến là screen hoặc activity). Một page thường tương ứng với một slice, tuy nhiên, nếu có nhiều page rất giống nhau, chúng có thể được nhóm vào một slice, ví dụ registration và login form.
+
+Không có giới hạn về lượng code bạn có thể đặt trong page slice miễn là team của bạn vẫn thấy dễ navigate. Nếu một UI block trên page không được tái sử dụng, hoàn toàn ổn khi giữ nó bên trong page slice.
+
+Trong page slice bạn thường có thể tìm thấy UI của page cũng như loading state và error boundary (`📁 ui`) và các data fetching và mutating request (`📁 api`). Không phổ biến đề page có data model riêng biệt, và các bit state nhỏ có thể được giữ trong chính các component.
+
+### Processes
+
+:::caution
+
+Layer này đã bị deprecated. Phiên bản hiện tại của spec khuyên tránh nó và chuyển nội dung của nó sang `features` và `app` thay vào đó.
+
+:::
+
+Process là escape hatch cho các tương tác nhiều page.
+
+Layer này cố tình được để không định nghĩa. Hầu hết các ứng dụng không nên sử dụng layer này, và giữ logic cấp router và cấp server trên layer App. Chỉ cân nhắc sử dụng layer này khi layer App phát triển đủ lớn để trở nên không thể bảo trì và cần giảm tải.
+
+### App
+
+Mọi loại vấn đề app-wide, cả trong nghĩa kỹ thuật (ví dụ: context provider) và trong nghĩa business (ví dụ: analytics).
+
+Layer này thường không chứa slice, cũng giống như Shared, thay vào đó có các segment trực tiếp.
+
+Dưới đây là các segment mà bạn thường có thể tìm thấy trong layer này:
+
+- `📁 routes` — router configuration
+- `📁 store` — global store configuration
+- `📁 styles` — global style
+- `📁 entrypoint` — entrypoint đến application code, framework-specific
+
+[public-api-for-cross-imports]: /docs/reference/public-api#public-api-for-cross-imports
+[ext-remix]: https://remix.run
+[ext-sova-utility-dump]: https://dev.to/sergeysova/why-utils-helpers-is-a-dump-45fo

--- a/i18n/vi/docusaurus-plugin-content-docs/current/reference/public-api.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/reference/public-api.md
@@ -1,0 +1,155 @@
+---
+sidebar_position: 3
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+# Public API
+
+Public API là một _hợp đồng_ giữa một nhóm module, như một slice, và code sử dụng nó. Nó cũng hoạt động như một cổng kiểm soát, chỉ cho phép truy cập đến các đối tượng nhất định và chỉ thông qua public API đó.
+
+Trong thực tế, nó thường được triển khai dưới dạng file index với các re-export:
+
+```js title="pages/auth/index.js"
+export { LoginPage } from "./ui/LoginPage";
+export { RegisterPage } from "./ui/RegisterPage";
+```
+
+## Điều gì tạo nên một public API tốt?
+
+Một public API tốt làm cho việc sử dụng và tích hợp slice vào code khác trở nên thuận tiện và đáng tin cậy. Điều này có thể đạt được bằng cách thiết lập ba mục tiêu sau:
+
+1. Phần còn lại của ứng dụng phải được bảo vệ khỏi các thay đổi cấu trúc của slice, như refactoring
+1. Những thay đổi đáng kể trong hành vi của slice mà phá vỡ các kỳ vọng trước đó phải gây ra thay đổi trong public API
+1. Chỉ những phần cần thiết của slice mới nên được expose
+
+Mục tiêu cuối cùng có một số hàm ý thực tế quan trọng. Có thể rất hấp dẫn khi tạo wildcard re-export cho mọi thứ, đặc biệt trong giai đoạn phát triển đầu của slice, vì bất kỳ đối tượng mới nào bạn export từ các file cũng sẽ tự động được export từ slice:
+
+```js title="Bad practice, features/comments/index.js"
+// ❌ BAD CODE BELOW, DON'T DO THIS
+export * from "./ui/Comment";  // 👎 don't try this at home
+export * from "./model/comments";  // 💩 this is bad practice
+```
+
+Điều này làm tổn hại khả năng khám phá của slice vì bạn không thể dễ dàng biết được interface của slice này là gì. Không biết interface có nghĩa là bạn phải đào sâu vào code của slice để hiểu cách tích hợp nó. Một vấn đề khác là bạn có thể vô tình expose các module internal, điều này sẽ khiến refactoring trở nên khó khăn nếu ai đó bắt đầu phụ thuộc vào chúng.
+
+## Public API cho cross-imports {#public-api-for-cross-imports}
+
+Cross-import là tình huống khi một slice import từ slice khác trên cùng layer. Thông thường điều này bị cấm bởi [import rule on layers][import-rule-on-layers], nhưng thường có những lý do chính đáng để cross-import. Ví dụ, các business entity thường tham chiếu lẫn nhau trong thế giới thực, và tốt nhất là phản ánh những mối quan hệ này trong code thay vì tránh chúng.
+
+Cho mục đích này, có một loại public API đặc biệt, còn được biết đến với tên gọi `@x`-notation. Nếu bạn có entity A và B, và entity B cần import từ entity A, thì entity A có thể khai báo một public API riêng chỉ dành cho entity B.
+
+- `📂 entities`
+    - `📂 A`
+        - `📂 @x`
+            - `📄 B.ts` — một public API đặc biệt chỉ dành cho code bên trong `entities/B/`
+        - `📄 index.ts` — public API thông thường
+
+Sau đó code bên trong `entities/B/` có thể import từ `entities/A/@x/B`:
+
+```ts
+import type { EntityA } from "entities/A/@x/B";
+```
+
+Ký hiệu `A/@x/B` có nghĩa là "A crossed with B".
+
+:::note
+
+Hãy cố gắng giữ cross-import ở mức tối thiểu, và **chỉ sử dụng ký hiệu này trên layer Entities**, nơi mà việc loại bỏ cross-import thường là không hợp lý.
+
+:::
+
+## Vấn đề với index file
+
+Các index file như `index.js`, còn được gọi là barrel file, là cách phổ biến nhất để định nghĩa public API. Chúng dễ tạo, nhưng được biết đến là gây ra vấn đề với một số bundler và framework nhất định.
+
+### Circular import
+
+Circular import là khi hai hoặc nhiều file import lẫn nhau theo vòng tròn.
+
+<!-- TODO: add backgrounds to the images below, check on mobile -->
+
+<figure>
+    <img src={useBaseUrl("/img/circular-import-light.svg#light-mode-only")} width="60%" alt="Three files importing each other in a circle" />
+    <img src={useBaseUrl("/img/circular-import-dark.svg#dark-mode-only")} width="60%" alt="Three files importing each other in a circle" />
+    <figcaption>
+        Minh họa ở trên: ba file, `fileA.js`, `fileB.js`, và `fileC.js`, import lẫn nhau theo vòng tròn.
+    </figcaption>
+</figure>
+
+Những tình huống này thường khó khăn để bundler xử lý, và trong một số trường hợp chúng thậm chí có thể dẫn đến runtime error khó debug.
+
+Circular import có thể xảy ra mà không cần index file, nhưng việc có index file tạo ra cơ hội rõ ràng để vô tình tạo circular import. Điều này thường xảy ra khi bạn có hai object được expose trong public API của slice, ví dụ `HomePage` và `loadUserStatistics`, và `HomePage` cần truy cập `loadUserStatistics`, nhưng nó làm như thế này:
+
+```jsx title="pages/home/ui/HomePage.jsx"
+import { loadUserStatistics } from "../"; // importing from pages/home/index.js
+
+export function HomePage() { /* … */ }
+```
+
+```js title="pages/home/index.js"
+export { HomePage } from "./ui/HomePage";
+export { loadUserStatistics } from "./api/loadUserStatistics";
+```
+
+Tình huống này tạo ra circular import, vì `index.js` import `ui/HomePage.jsx`, nhưng `ui/HomePage.jsx` import `index.js`.
+
+Để ngăn chặn vấn đề này, hãy xem xét hai nguyên tắc sau. Nếu bạn có hai file, và một file import từ file kia:
+- Khi chúng ở trong cùng slice, luôn sử dụng import _relative_ và viết đầy đủ đường dẫn import
+- Khi chúng ở trong các slice khác nhau, luôn sử dụng import _absolute_, ví dụ với alias
+
+### Bundle lớn và tree-shaking bị hỏng trong Shared {#large-bundles}
+
+Một số bundler có thể gặp khó khăn trong việc tree-shake (loại bỏ code không được import) khi bạn có index file re-export mọi thứ.
+
+Thông thường đây không phải là vấn đề cho public API, vì nội dung của một module thường có liên quan chặt chẽ với nhau, nên bạn hiếm khi cần import một thứ và tree-shake đi thứ khác. Tuy nhiên, có hai trường hợp rất phổ biến khi các quy tắc thông thường của public API trong FSD có thể dẫn đến vấn đề — `shared/ui` và `shared/lib`.
+
+Hai folder này đều là tập hợp các thứ không liên quan mà thường không cần thiết tất cả ở một nơi. Ví dụ, `shared/ui` có thể có module cho mỗi component trong UI library:
+
+- `📂 shared/ui/`
+    - `📁 button`
+    - `📁 text-field`
+    - `📁 carousel`
+    - `📁 accordion`
+
+Vấn đề này trở nên tồi tệ hơn khi một trong những module này có dependency nặng, như syntax highlighter hoặc drag'n'drop library. Bạn không muốn kéo chúng vào mọi page sử dụng thứ gì đó từ `shared/ui`, ví dụ như một button.
+
+Nếu bundle của bạn phát triển không mong muốn do một public API duy nhất trong `shared/ui` hoặc `shared/lib`, được khuyến nghị thay vào đó hãy có một index file riêng cho mỗi component hoặc library:
+
+- `📂 shared/ui/`
+    - `📂 button`
+        - `📄 index.js`
+    - `📂 text-field`
+        - `📄 index.js`
+
+Sau đó các consumer của những component này có thể import chúng trực tiếp như thế này:
+
+```js title="pages/sign-in/ui/SignInPage.jsx"
+import { Button } from '@/shared/ui/button';
+import { TextField } from '@/shared/ui/text-field';
+```
+
+### Không có bảo vệ thực sự chống lại việc bỏ qua public API
+
+Khi bạn tạo index file cho slice, bạn không thực sự cấm ai đó không sử dụng nó và import trực tiếp. Điều này đặc biệt là vấn đề với auto-import, vì có nhiều nơi mà một object có thể được import, nên IDE phải quyết định cho bạn. Đôi khi nó có thể chọn import trực tiếp, phá vỡ quy tắc public API trên slice.
+
+Để tự động phát hiện những vấn đề này, chúng tôi khuyên sử dụng [Steiger][ext-steiger], một architectural linter với ruleset cho Feature-Sliced Design.
+
+### Hiệu suất bundler kém hơn trên các dự án lớn
+
+Việc có một lượng lớn index file trong dự án có thể làm chậm development server, như TkDodo đã lưu ý trong [bài viết "Please Stop Using Barrel Files"][ext-please-stop-using-barrel-files] của anh ấy.
+
+Có một số điều bạn có thể làm để giải quyết vấn đề này:
+1. Lời khuyên giống như trong vấn đề ["Bundle lớn và tree-shaking bị hỏng trong Shared"](#large-bundles) — có index file riêng cho từng component/library trong `shared/ui` và `shared/lib` thay vì một file lớn
+2. Tránh có index file trong segment trên các layer có slice.  
+   Ví dụ, nếu bạn có index cho feature "comments", `📄 features/comments/index.js`, thì không có lý do gì để có thêm index cho segment `ui` của feature đó, `📄 features/comments/ui/index.js`.
+3. Nếu bạn có một dự án rất lớn, có khả năng cao là ứng dụng của bạn có thể được chia thành nhiều chunk lớn.  
+   Ví dụ, Google Docs có trách nhiệm rất khác nhau cho document editor và file browser. Bạn có thể tạo monorepo setup nơi mỗi package là một FSD root riêng biệt, với bộ layer riêng. Một số package chỉ có thể có layer Shared và Entities, những package khác có thể chỉ có Pages và App, những package khác nữa có thể bao gồm Shared nhỏ của riêng mình, nhưng vẫn sử dụng cái lớn từ package khác.
+
+   <!-- TODO: add a link to a page that explains this in more detail (when one will exist) -->
+
+<!-- TODO: discuss issues with mixing server/client code in Next/Remix -->
+
+[import-rule-on-layers]: /docs/reference/layers#import-rule-on-layers
+[ext-steiger]: https://github.com/feature-sliced/steiger
+[ext-please-stop-using-barrel-files]: https://tkdodo.eu/blog/please-stop-using-barrel-files

--- a/i18n/vi/docusaurus-plugin-content-docs/current/reference/slices-segments.mdx
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/reference/slices-segments.mdx
@@ -1,0 +1,73 @@
+---
+title: Slice và segment
+sidebar_position: 2
+pagination_next: reference/public-api
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+# Slice và segment
+
+## Slice
+
+Slice là cấp độ thứ hai trong hệ thống phân cấp tổ chức của Feature-Sliced Design. Mục đích chính của chúng là nhóm code theo ý nghĩa của nó đối với sản phẩm, business, hoặc chỉ đơn giản là application.
+
+Tên của các slice không được chuẩn hóa vì chúng được xác định trực tiếp bởi business domain của ứng dụng của bạn. Ví dụ, một photo gallery có thể có các slice `photo`, `effects`, `gallery-page`. Một mạng xã hội sẽ yêu cầu các slice khác nhau, ví dụ `post`, `comments`, `news-feed`.
+
+Các layer Shared và App không chứa slice. Đó là vì Shared không nên chứa business logic nào cả, do đó không có ý nghĩa gì đối với sản phẩm, và App chỉ nên chứa code liên quan đến toàn bộ ứng dụng, vì vậy không cần phải chia tách.
+
+### Zero coupling và high cohesion {#zero-coupling-high-cohesion}
+
+Slice được thiết kế để là các nhóm file code độc lập và có tính gắn kết cao. Hình minh họa dưới đây có thể giúp hình dung các khái niệm khó hiểu về _cohesion_ và _coupling_:
+
+<figure>
+    <img src={useBaseUrl("/img/coupling-cohesion-light.svg#light-mode-only")} alt="" />
+    <img src={useBaseUrl("/img/coupling-cohesion-dark.svg#dark-mode-only")} alt="" />
+    <figcaption>
+        Image inspired by https://enterprisecraftsmanship.com/posts/cohesion-coupling-difference/
+    </figcaption>
+</figure>
+
+Một slice lý tưởng là độc lập với các slice khác trên layer của nó (zero coupling) và chứa hầu hết code liên quan đến mục tiêu chính của nó (high cohesion).
+
+Tính độc lập của các slice được thực thi bởi [import rule trên layer][layers--import-rule]:
+
+> _Một module (file) trong slice chỉ có thể import các slice khác khi chúng được đặt trên các layer thấp hơn một cách nghiêm ngặt._
+
+### Public API rule trên slice
+
+Bên trong slice, code có thể được tổ chức theo bất kỳ cách nào mà bạn muốn. Điều đó không gây ra vấn đề gì miễn là slice cung cấp public API tốt cho các slice khác sử dụng nó. Điều này được thực thi với **public API rule trên slice**:
+
+> _Mỗi slice (và segment trên các layer không có slice) phải chứa một định nghĩa public API._
+>
+> _Các module bên ngoài slice/segment này chỉ có thể tham chiếu public API, không phải cấu trúc file nội bộ của slice/segment._
+
+Đọc thêm về lý lẽ của public API và best practice để tạo một cái trong [Public API reference][ref-public-api].
+
+### Nhóm slice
+
+Các slice liên quan chặt chẽ có thể được nhóm về mặt cấu trúc trong một folder, nhưng chúng nên thực hiện các quy tắc cô lập giống như các slice khác — không nên có **code sharing** trong folder đó.
+
+![Features "compose", "like" and "delete" grouped in a folder "post". In that folder there is also a file "some-shared-code.ts" that is crossed out to imply that it's not allowed.](/img/graphic-nested-slices.svg)
+
+## Segment
+
+Segment là cấp độ thứ ba và cuối cùng trong hệ thống phân cấp tổ chức, và mục đích của chúng là nhóm code theo bản chất kỹ thuật của nó.
+
+Có một số tên segment được chuẩn hóa:
+
+- `ui` — mọi thứ liên quan đến hiển thị UI: UI component, date formatter, style, v.v.
+- `api` — tương tác backend: request function, data type, mapper, v.v.
+- `model` — data model: schema, interface, store, và business logic.
+- `lib` — library code mà các module khác trên slice này cần.
+- `config` — configuration file và feature flag.
+
+Xem [trang Layer][layers--layer-definitions] để biết ví dụ về cách sử dụng từng segment này trên các layer khác nhau.
+
+Bạn cũng có thể tạo custom segment. Những nơi phổ biến nhất cho custom segment là layer App và layer Shared, nơi mà slice không có ý nghĩa.
+
+Hãy đảm bảo rằng tên của những segment này mô tả mục đích của nội dung, không phải bản chất của nó. Ví dụ, `components`, `hooks`, và `types` là những tên segment tệ vì chúng không hữu ích khi bạn đang tìm kiếm code.
+
+[layers--layer-definitions]: /docs/reference/layers#layer-definitions
+[layers--import-rule]: /docs/reference/layers#import-rule-on-layers
+[ref-public-api]: /docs/reference/public-api

--- a/i18n/vi/docusaurus-theme-classic/footer.json
+++ b/i18n/vi/docusaurus-theme-classic/footer.json
@@ -1,0 +1,66 @@
+{
+    "link.title.Specs": {
+        "message": "Specs",
+        "description": "The title of the footer links column with title=Specs in the footer"
+    },
+    "link.title.Community": {
+        "message": "Cộng đồng",
+        "description": "The title of the footer links column with title=Community in the footer"
+    },
+    "link.title.More": {
+        "message": "Thêm",
+        "description": "The title of the footer links column with title=More in the footer"
+    },
+    "link.item.label.Documentation": {
+        "message": "Tài liệu",
+        "description": "The label of footer link with label=Documentation linking to /docs"
+    },
+    "link.item.label.Discussions": {
+        "message": "Thảo luận",
+        "description": "The label of footer link with label=Discussions linking to https://github.com/feature-sliced/documentation/discussions"
+    },
+    "link.item.label.Community": {
+        "message": "Cộng đồng",
+        "description": "The label of the footer link with label=Community linking to /community"
+    },
+    "link.item.label.Help": {
+        "message": "Trợ giúp",
+        "description": "The label of the footer link with label=Help linking to /nav"
+    },
+    "link.item.label.License": {
+        "message": "License",
+        "description": "The label of footer link with label=License linking to LICENSE"
+    },
+    "link.item.label.Contribution Guide (RU)": {
+        "message": "Hướng dẫn đóng góp (RU)",
+        "description": "The label of footer link with label=Contribution Guide (RU) linking to CONTRIBUTING.md"
+    },
+    "link.item.label.Discord": {
+        "message": "Discord",
+        "description": "The label of footer link with label=Discord linking to https://discord.com/invite/S8MzWTUsmp"
+    },
+    "link.item.label.Telegram": {
+        "message": "Telegram",
+        "description": "The label of footer link with label=Telegram linking to https://t.me/feature_sliced"
+    },
+    "link.item.label.Twitter": {
+        "message": "Twitter",
+        "description": "The label of footer link with label=Twitter linking to https://twitter.com/feature_sliced"
+    },
+    "link.item.label.Open Collective": {
+        "message": "Open Collective",
+        "description": "The label of footer link with label=Open Collective linking to https://opencollective.com/feature-sliced"
+    },
+    "link.item.label.YouTube": {
+        "message": "YouTube",
+        "description": "The label of footer link with label=YouTube linking to https://www.youtube.com/c/FeatureSlicedDesign"
+    },
+    "link.item.label.GitHub": {
+        "message": "GitHub",
+        "description": "The label of footer link with label=GitHub linking to https://github.com/feature-sliced"
+    },
+    "copyright": {
+        "message": "Bản quyền © 2018-2025  Feature-Sliced Design",
+        "description": "The footer copyright"
+    }
+}

--- a/i18n/vi/docusaurus-theme-classic/navbar.json
+++ b/i18n/vi/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,26 @@
+{
+  "title": {
+    "message": "FSD",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "Logo",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.📖 Docs": {
+    "message": "📖 Tài liệu",
+    "description": "Navbar item with label 📖 Docs"
+  },
+  "item.label.💫 Community": {
+    "message": "💫 Cộng đồng",
+    "description": "Navbar item with label 💫 Community"
+  },
+  "item.label.📝 Blog": {
+    "message": "📝 Blog",
+    "description": "Navbar item with label 📝 Blog"
+  },
+  "item.label.🛠 Examples": {
+    "message": "🛠 Ví dụ",
+    "description": "Navbar item with label 🛠 Examples"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "start:uz": "docusaurus start --locale uz",
         "start:kr": "docusaurus start --locale kr",
         "start:ja": "docusaurus start --locale ja",
+        "start:vi": "docusaurus start --locale vi",
         "build": "docusaurus build",
         "swizzle": "docusaurus swizzle",
         "test": "pnpm run test:lint && pnpm run build",


### PR DESCRIPTION
- Add Vietnamese locale configuration
- Translate all documentation sections:
  - Get Started: overview, tutorial, FAQ, cheatsheet
  - Guides: examples, migration, tech, issues
  - Reference: layers, slices-segments, public-api
  - About: mission, motivation, understanding, promote
  - Community pages
- Translate UI messages and navigation labels
- Add start script for Vietnamese

## Background

Thank you for creating such a great FSD architecture for building frontend applications.
I would like to translate FSD's documentation into Vietnamese so that more Vietnamese developers can learn about this amazing architecture.







<!-- 
  Hi from the Feature-Sliced Design core team! 👋

  Thank you for taking the time to contribute.
  We have a set of guidelines for contibutors that you might want to read:

    https://github.com/feature-sliced/documentation/blob/master/CONTRIBUTING.md

  We encourage self-reviewing the changes before submitting a PR ✅. 
  Here's a nice article that has some pro-tips:

    https://blog.beanbaginc.com/2014/12/01/practicing-effective-self-review/
    
-->
