### PR TITLE
fix: use external URL for Lunaria dashboard favicon

### DIFF
--- a/lunaria.config.json
+++ b/lunaria.config.json
@@ -13,7 +13,12 @@
         "basesToHide": ["src/content/docs"],
         "customCss": ["./src/styles/lunaria.css"],
         "favicon": {
-            "inline": "./static/img/favicon/adaptive.svg"
+            "external": [
+                {
+                    "link": "https://fsd.how/img/favicon/adaptive.svg",
+                    "type": "image/svg+xml"
+                }
+            ]
         }
     },
     "defaultLocale": {


### PR DESCRIPTION
## Background

@lunariajs/core@0.1.1 does not escape inline SVG favicons when generating data URIs.

The # characters in the SVG are treated as URL fragment markers, which breaks the generated favicon. This switches the favicon to an external SVG file as a workaround.

<img width="1191" height="133" alt="스크린샷 2026-06-11 오전 12 01 43" src="https://github.com/user-attachments/assets/27d81d58-730e-4272-be93-ab412fbbf784" />
