### PR TITLE
docs(kr): add Server and client public APIs and Environment-specific Public APIs sections

### DIFF
--- a/src/content/docs/kr/docs/guides/tech/with-nextjs.mdx
+++ b/src/content/docs/kr/docs/guides/tech/with-nextjs.mdx
@@ -52,6 +52,16 @@ App Router에서 `app` 폴더는 라우트 구조로 사용됩니다. 반면 FSD
 export { ExamplePage as default, metadata } from '@/pages/example';
 ```
 
+### Server and client public APIs \{#server-and-client-public-apis\}
+
+Next.js App Router에서는 하나의 Slice 안에 클라이언트에서 사용할 수 있는 모듈과 서버 전용 모듈이 함께 존재할 수 있습니다.
+
+서버 전용 모듈을 `index.ts`에서 export하면, Client Component가 해당 Slice를 import할 때 서버 전용 코드가 클라이언트 모듈 그래프에 포함되어 빌드 오류가 발생할 수 있습니다.
+
+이 문제가 발생하면 Public API에 `index.server.ts`를 추가합니다.
+
+* `index.server.ts`: Server Component나 `server-only`로 표시된 데이터 접근 함수처럼 서버에서만 import해야 하는 모듈
+
 ### Middleware \{#middleware\}
 
 middleware를 사용한다면 Next.js의 `app`, `pages` 폴더와 함께 프로젝트 루트에 둡니다.

--- a/src/content/docs/kr/docs/reference/public-api.mdx
+++ b/src/content/docs/kr/docs/reference/public-api.mdx
@@ -90,6 +90,16 @@ Cross-import는 **반드시 최소화**해야 하며, 허용한다면 **Entity L
 
 </Aside>
 
+## Environment-specific Public APIs
+
+Slice의 Public API는 일반적으로 `index.ts`로 표현하며, 이를 자유롭게 커스터마이즈하는 것은 권장하지 않습니다.
+
+다만 같은 Slice 안의 모듈이라도 서로 다른 환경에서 동작해야 하는 경우가 있습니다. 이런 모듈을 하나의 `index.ts`에서 함께 export하면 환경 간 경계가 깨지거나, 번들러가 함께 묶여서는 안 되는 코드까지 잘못 포함할 수 있습니다.
+
+실제로 이러한 문제가 발생한다면, 실행 환경에 맞는 파일을 추가하여 Public API를 분리합니다.
+
+예시는 [Usage with Next.js의 Server and client public APIs](/kr/docs/guides/tech/with-nextjs#server-and-client-public-apis)를 참고하세요.
+
 ## Index File 사용 시 주의사항
 
 ### Circular Import (순환 참조)


### PR DESCRIPTION
## Background

The sections on environment-specific Public APIs and server and client Public APIs have been translated into Korean and added to the documentation. cc. #924