### PR TITLE
docs: add guide for api request (#934) 

### DIFF
--- a/src/content/docs/tr/docs/guides/examples/api-requests.mdx
+++ b/src/content/docs/tr/docs/guides/examples/api-requests.mdx
@@ -1,0 +1,144 @@
+---
+title: API İsteklerini Yönetme
+sidebar:
+  order: 4
+---
+
+import { FileTree, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
+
+## Paylaşılan API İstekleri \{#shared-api-requests\}
+
+Yaygın API istek mantığını `shared/api` dizinine yerleştirerek başlayın. Bu, istekleri uygulamanız genelinde yeniden kullanmayı kolaylaştırır ve daha hızlı prototipleme yapmanıza yardımcı olur. Birçok proje için API çağrıları için ihtiyacınız olan tek şey budur.
+
+Tipik bir dosya yapısı şu şekilde olacaktır:
+
+<FileTree>
+- shared/
+  - client.ts
+  - index.ts
+  - endpoints/
+    - login.ts
+</FileTree>
+
+`client.ts` dosyası HTTP istek kurulumunuzu merkezileştirir. Seçtiğiniz yöntemi (`fetch()` veya bir `axios` örneği gibi) sarar ve aşağıdakiler gibi yaygın yapılandırmaları işler:
+
+- Backend temel URL'si.
+- Varsayılan başlıklar (ör. kimlik doğrulama için).
+- Veri serileştirme.
+
+İşte `axios` ve `fetch` için örnekler:
+
+<Tabs>
+
+<TabItem label="Axios">
+```ts title="shared/api/client.ts"
+// axios kullanan bir örnek
+import axios from 'axios';
+
+export const client = axios.create({
+  baseURL: 'https://your-api-domain.com/api/',
+  timeout: 5000,
+  headers: { 'X-Custom-Header': 'my-custom-value' }
+});
+```
+</TabItem>
+
+<TabItem label="Fetch">
+```ts title="shared/api/client.ts"
+export const client = {
+  async post(endpoint: string, body: any, options?: RequestInit) {
+    const response = await fetch(`https://your-api-domain.com/api${endpoint}`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom-Header': 'my-custom-value',
+        ...options?.headers,
+      },
+    });
+    return response.json();
+  }
+  // ... put, delete, vb. gibi diğer metodlar
+};
+```
+</TabItem>
+
+</Tabs>
+
+Bireysel API istek işlevlerinizi `shared/api/endpoints` içinde düzenleyin ve bunları API uç noktasına göre gruplandırın.
+
+<Aside>
+
+Örneklerin odak noktasını korumak için form etkileşimini ve doğrulamayı atlıyoruz. Zod veya Valibot gibi kütüphaneler hakkında daha fazla bilgi için [Tip Doğrulama ve Şemalar](/tr/docs/guides/examples/types#type-validation-schemas-and-zod) makalesine bakın.
+
+</Aside>
+
+```ts title="shared/api/endpoints/login.ts"
+import { client } from '../client';
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export function login(credentials: LoginCredentials) {
+  return client.post('/login', credentials);
+}
+```
+İstek işlevlerinizi dışa aktarmak için `shared/api` içinde bir `index.ts` dosyası kullanın.
+
+```ts title="shared/api/index.ts"
+export { client } from './client'; // Eğer istemcinin kendisini dışa aktarmak istiyorsanız
+export { login } from './endpoints/login';
+export type { LoginCredentials } from './endpoints/login';
+```
+
+## Dilim Özel API İstekleri \{#slice-specific-api-requests\}
+
+Bir API isteği yalnızca belirli bir dilim (tek bir sayfa veya özellik gibi) tarafından kullanılıyorsa ve yeniden kullanılmayacaksa, onu o dilimin `api` segmentine yerleştirin. Bu, dilime özgü mantığı düzgün bir şekilde içeride tutar.
+
+<FileTree>
+- pages/
+  - login/
+    - index.ts
+    - api/
+      - login.ts
+    - ui/
+      - LoginPage.tsx
+</FileTree>
+
+```ts title="pages/login/api/login.ts"
+import { client } from 'shared/api';
+
+interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export function login(credentials: LoginCredentials) {
+  return client.post('/login', credentials);
+}
+```
+
+Uygulamadaki başka hiçbir yerin bu isteğe ihtiyaç duyması olası olmadığından, sayfanın genel API'sinde `login()` işlevini dışa aktarmanıza gerek yoktur.
+
+<Aside>
+
+API çağrılarını ve yanıt tiplerini zamanından önce `entities` katmanına yerleştirmekten kaçının. Backend yanıtları, frontend varlıklarınızın ihtiyaç duyduğundan farklı olabilir. `shared/api` veya bir dilimin `api` segmentindeki API mantığı, verileri uygun şekilde dönüştürmenize olanak tanıyarak varlıkların frontend sorunlarına odaklanmasını sağlar.
+
+</Aside>
+
+## İstemci Üreticilerini Kullanma \{#client-generators\}
+
+Backend'iniz bir OpenAPI spesifikasyonuna sahipse, [orval](https://orval.dev/) veya [openapi-typescript](https://openapi-ts.dev/) gibi araçlar sizin için API tiplerini ve istek işlevlerini üretebilir. Üretilen kodu örneğin `shared/api/openapi` içine yerleştirin. Bu tiplerin ne olduğunu ve nasıl üretileceğini belgelemek için `README.md` eklediğinizden emin olun.
+
+## Sunucu Durumu (Server State) Kütüphaneleriyle Entegrasyon \{#server-state-libraries\}
+
+[TanStack Query (React Query)](https://tanstack.com/query/latest) veya [Pinia Colada](https://pinia-colada.esm.dev/) gibi sunucu durumu kütüphaneleri kullanırken, tipleri veya önbellek anahtarlarını (cache keys) dilimler arasında paylaşmanız gerekebilir. Aşağıdakiler için `shared` katmanını kullanın:
+
+- API veri tipleri
+- Önbellek anahtarları
+- Yaygın sorgu/mutasyon (query/mutation) seçenekleri
+
+Sunucu durumu kütüphaneleriyle çalışma hakkında daha fazla ayrıntı için [React Query makalesine](/tr/docs/guides/tech/with-react-query) bakın.

--- a/src/content/docs/tr/docs/guides/examples/page-layout.mdx
+++ b/src/content/docs/tr/docs/guides/examples/page-layout.mdx
@@ -1,0 +1,120 @@
+---
+title: Sayfa Düzenleri
+sidebar:
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Bu kılavuz, bir _sayfa düzeni_ (page layout) soyutlamasını inceler — birkaç sayfa aynı genel yapıyı paylaştığında ve yalnızca ana içerik bakımından farklılık gösterdiğinde kullanılır.
+
+<Aside>
+
+Aradığınız soru bu kılavuzda kapsanmıyor mu? Bu makaleye geri bildirim bırakarak (sağdaki mavi buton) sorunuzu paylaşın; biz de bu kılavuzu genişletmeyi değerlendirelim!
+
+</Aside>
+
+## Basit düzen
+
+En basit düzen bu sayfada görülebilir. Site navigasyonuna sahip bir üst bilgi (header), iki yan çubuk (sidebar) ve dış bağlantılar içeren bir alt bilgi (footer) bulunur. Karmaşık bir iş mantığı (business logic) yoktur ve tek dinamik parçalar yan çubuklar ile üst bilginin sağ tarafındaki değiştiricilerdir (switcher). Böyle bir düzen tamamen `shared/ui` veya `app/layouts` içine yerleştirilebilir ve props aracılığıyla yan çubukların içeriği doldurulabilir:
+
+```tsx title="shared/ui/layout/Layout.tsx"
+import { Link, Outlet } from "react-router-dom";
+import { useThemeSwitcher } from "./useThemeSwitcher";
+
+export function Layout({ siblingPages, headings }) {
+  const [theme, toggleTheme] = useThemeSwitcher();
+
+  return (
+    <div>
+      <header>
+        <nav>
+          <ul>
+            <li> <Link to="/">Home</Link> </li>
+            <li> <Link to="/docs">Docs</Link> </li>
+            <li> <Link to="/blog">Blog</Link> </li>
+          </ul>
+        </nav>
+        <button onClick={toggleTheme}>{theme}</button>
+      </header>
+      <main>
+        <SiblingPageSidebar siblingPages={siblingPages} />
+        <Outlet /> {/* Ana içerik buraya gelir */}
+        <HeadingsSidebar headings={headings} />
+      </main>
+      <footer>
+        <ul>
+          <li>GitHub</li>
+          <li>Twitter</li>
+        </ul>
+      </footer>
+    </div>
+  );
+}
+```
+
+```ts title="shared/ui/layout/useThemeSwitcher.ts"
+export function useThemeSwitcher() {
+  const [theme, setTheme] = useState("light");
+
+  function toggleTheme() {
+    setTheme(theme === "light" ? "dark" : "light");
+  }
+
+  useEffect(() => {
+    document.body.classList.remove("light", "dark");
+    document.body.classList.add(theme);
+  }, [theme]);
+
+  return [theme, toggleTheme] as const;
+}
+```
+
+Yan çubukların kodu okuyucuya bir alıştırma olarak bırakılmıştır 😉.
+
+## Düzenler nerede konumlandırılmalıdır? \{#where-to-put-layouts\}
+
+Düzen bileşenleri genellikle birden fazla rota (route) arasında paylaşılan veri işleme, durum yönetimi (state management), erişim kontrolü ve kullanıcı eylemlerini bir araya getirme (compose) ihtiyacı duyar.
+
+[React Router][ext-react-router]'da iç içe geçmiş (nested) alt rotalar `/users`, `/users/:id` ve `/users/:id/settings` gibi ortak bir URL yolunu paylaşabilir. Aynı mantığı her sayfada tekrarlamak yerine, yönlendiricinin (router) iç içe geçme özelliklerini kullanarak ortak bir düzeni ve rota seviyesindeki mantığı tek bir yerde uygulayabilirsiniz.
+
+Bir düzenin konumu, yapısal karmaşıklığından ziyade **kapsamı ve sorumluluğu** temel alınarak belirlenmelidir.
+
+* Tüm uygulamadan veya yönlendirme yapısından sorumlu düzenler `app` katmanına yerleştirilmelidir.
+* Belirli bir sayfaya veya rota grubuna özgü düzenler `pages` katmanına yerleştirilmelidir.
+* İş bağlamı (business context) olmadan yeniden kullanılabilir olan düzen UI bileşenleri `shared/ui` katmanına yerleştirilebilir.
+* Belirli bir kullanıcı eylemi veya kullanıcı akışı etrafında merkezlenen ve birden fazla sayfada yeniden kullanılan düzenler, ilgili `features` diliminde (slice) uygulanabilir.
+
+`shared` katmanındaki bir düzenin doğrudan `features`, `entities` veya `pages` katmanlarından içe aktarım (import) yapması [katmanlardaki içe aktarma kuralını][import-rule-on-layers] ihlal eder. `app` ve `pages` katmanlarındaki modüller bir ekranı oluşturmak (compose) için alt katmanlardaki modülleri içe aktarabilir.
+
+> Bir modül yalnızca ait olduğu katmanın altındaki katmanlardan modül içe aktarabilir.
+
+Bir düzeni ayrı bir modüle çıkarmadan önce şunları göz önünde bulundurun:
+
+* Bu düzen gerçekten birden fazla rota genelinde yeniden kullanılıyor mu?
+* Belirli bir sayfaya veya rota yapısına özgü mü?
+* Yeniden kullanılabilir birim düzenin kendisi mi, yoksa yalnızca düzen içinde kullanılan kullanıcı eylemi mi?
+
+Yalnızca az sayıda sayfa tarafından kullanılan ve belirli bir ekran yapısına bağlı olan bir düzeni, doğrudan ilgili `page` veya rota yapılandırmasında tanımlamak daha basit olabilir.
+
+1. **App katmanında bir rota düzeni yapılandırın**  
+   Yönlendiricinin iç içe geçme özelliklerini kullanarak ortak URL yoluna sahip birden fazla rotayı gruplayabilir ve `app` katmanında tek bir düzen atayabilirsiniz.
+   `app` içinde yer alan bir düzen, katmanlardaki içe aktarma kuralını ihlal etmeden `pages`, `features`, `entities` ve `shared` katmanlarındaki modülleri bir araya getirebilir (compose).
+
+2. **Özellik (Feature) UI bileşenlerini render props veya slot'lar aracılığıyla aktarın**  
+   React'te [render props][ext-render-props] desenini kullanabilirsiniz. Vue'da ise [slots][ext-vue-slots] kullanabilirsiniz.
+   Bu yaklaşımda `shared` içindeki düzen yalnızca ortak UI yapısını sağlarken, gerekli olan özellik UI bileşeni `app` veya `pages` katmanından aktarılır. Bu, düzenin belirli bir özelliğe doğrudan bağımlı olmadan gerekli ekranı oluşturmasını (compose) sağlar.
+
+3. **Doğrudan bir sayfa içinde tanımlayın**  
+   Yalnızca belirli bir sayfa tarafından kullanılan bir düzen, ayrı bir soyutlama eklenmeden doğrudan ilgili `page` içinde tanımlanabilir.
+   Kod tekrarı az olduğunda ve düzenin sık sık değişmesi muhtemel olmadığında, onu ortak bir modüle ayırmaya gerek yoktur.
+
+## Daha fazla okuma
+
+- React ve Remix (React Router'a eşdeğer) ile kimlik doğrulama içeren bir düzenin nasıl kurulacağına dair bir örnek [öğreticide][tutorial] bulunmaktadır.
+
+[tutorial]: /tr/docs/get-started/tutorial
+[import-rule-on-layers]: /tr/docs/reference/layers#import-rule-on-layers
+[ext-react-router]: https://reactrouter.com/
+[ext-render-props]: https://www.patterns.dev/react/render-props-pattern/
+[ext-vue-slots]: https://vuejs.org/guide/components/slots

--- a/src/content/docs/tr/docs/guides/examples/types.mdx
+++ b/src/content/docs/tr/docs/guides/examples/types.mdx
@@ -372,7 +372,7 @@ Segment seçimi de kullanım konumlarına göre belirlenmelidir. Örneğin enum'
 
 Genel backend yanıt durumları veya tasarım sistemi token'ları gibi bazı enum'lar projenin tamamında gerçekten ortaktır. Bu durumda bunları Shared katmanına yerleştirebilir ve enum'ın temsil ettiği şeye göre segmenti seçebilirsiniz (yanıt durumları için `api`, tasarım token'ları için `ui` vb.).
 
-## Tip doğrulama şemaları ve Zod
+## Tip doğrulama şemaları ve Zod \{#type-validation-schemas-and-zod\}
 
 Verilerinizin belirli bir şekle veya kısıtlamalara uyup uymadığını doğrulamak istiyorsanız, bir doğrulama şeması (validation schema) tanımlayabilirsiniz. TypeScript'te bu iş için popüler bir kütüphane [Zod][ext-zod]'dur. Doğrulama şemaları da mümkün olduğunca onları kullanan kodla aynı yerde (colocated) bulunmalıdır.
 


### PR DESCRIPTION
## Background

Relates to #934. 
Continuing the Turkish localization effort. This PR adds the translation for the api request section.

## Changelog

* Translated the api request page (`src/content/docs/tr/docs/guides/examples/api-requests.mdx`)