### PR TITLE
docs: add guide for from a custom architecture Turkish documentation (#934)

### DIFF
--- a/src/content/docs/tr/docs/guides/examples/page-layout.mdx
+++ b/src/content/docs/tr/docs/guides/examples/page-layout.mdx
@@ -1,0 +1,120 @@
+---
+title: Sayfa Düzenleri
+sidebar:
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Bu kılavuz, bir _sayfa düzeni_ (page layout) soyutlamasını inceler — birkaç sayfa aynı genel yapıyı paylaştığında ve yalnızca ana içerik bakımından farklılık gösterdiğinde kullanılır.
+
+<Aside>
+
+Aradığınız soru bu kılavuzda kapsanmıyor mu? Bu makaleye geri bildirim bırakarak (sağdaki mavi buton) sorunuzu paylaşın; biz de bu kılavuzu genişletmeyi değerlendirelim!
+
+</Aside>
+
+## Basit düzen
+
+En basit düzen bu sayfada görülebilir. Site navigasyonuna sahip bir üst bilgi (header), iki yan çubuk (sidebar) ve dış bağlantılar içeren bir alt bilgi (footer) bulunur. Karmaşık bir iş mantığı (business logic) yoktur ve tek dinamik parçalar yan çubuklar ile üst bilginin sağ tarafındaki değiştiricilerdir (switcher). Böyle bir düzen tamamen `shared/ui` veya `app/layouts` içine yerleştirilebilir ve props aracılığıyla yan çubukların içeriği doldurulabilir:
+
+```tsx title="shared/ui/layout/Layout.tsx"
+import { Link, Outlet } from "react-router-dom";
+import { useThemeSwitcher } from "./useThemeSwitcher";
+
+export function Layout({ siblingPages, headings }) {
+  const [theme, toggleTheme] = useThemeSwitcher();
+
+  return (
+    <div>
+      <header>
+        <nav>
+          <ul>
+            <li> <Link to="/">Home</Link> </li>
+            <li> <Link to="/docs">Docs</Link> </li>
+            <li> <Link to="/blog">Blog</Link> </li>
+          </ul>
+        </nav>
+        <button onClick={toggleTheme}>{theme}</button>
+      </header>
+      <main>
+        <SiblingPageSidebar siblingPages={siblingPages} />
+        <Outlet /> {/* Ana içerik buraya gelir */}
+        <HeadingsSidebar headings={headings} />
+      </main>
+      <footer>
+        <ul>
+          <li>GitHub</li>
+          <li>Twitter</li>
+        </ul>
+      </footer>
+    </div>
+  );
+}
+```
+
+```ts title="shared/ui/layout/useThemeSwitcher.ts"
+export function useThemeSwitcher() {
+  const [theme, setTheme] = useState("light");
+
+  function toggleTheme() {
+    setTheme(theme === "light" ? "dark" : "light");
+  }
+
+  useEffect(() => {
+    document.body.classList.remove("light", "dark");
+    document.body.classList.add(theme);
+  }, [theme]);
+
+  return [theme, toggleTheme] as const;
+}
+```
+
+Yan çubukların kodu okuyucuya bir alıştırma olarak bırakılmıştır 😉.
+
+## Düzenler nerede konumlandırılmalıdır? \{#where-to-put-layouts\}
+
+Düzen bileşenleri genellikle birden fazla rota (route) arasında paylaşılan veri işleme, durum yönetimi (state management), erişim kontrolü ve kullanıcı eylemlerini bir araya getirme (compose) ihtiyacı duyar.
+
+[React Router][ext-react-router]'da iç içe geçmiş (nested) alt rotalar `/users`, `/users/:id` ve `/users/:id/settings` gibi ortak bir URL yolunu paylaşabilir. Aynı mantığı her sayfada tekrarlamak yerine, yönlendiricinin (router) iç içe geçme özelliklerini kullanarak ortak bir düzeni ve rota seviyesindeki mantığı tek bir yerde uygulayabilirsiniz.
+
+Bir düzenin konumu, yapısal karmaşıklığından ziyade **kapsamı ve sorumluluğu** temel alınarak belirlenmelidir.
+
+* Tüm uygulamadan veya yönlendirme yapısından sorumlu düzenler `app` katmanına yerleştirilmelidir.
+* Belirli bir sayfaya veya rota grubuna özgü düzenler `pages` katmanına yerleştirilmelidir.
+* İş bağlamı (business context) olmadan yeniden kullanılabilir olan düzen UI bileşenleri `shared/ui` katmanına yerleştirilebilir.
+* Belirli bir kullanıcı eylemi veya kullanıcı akışı etrafında merkezlenen ve birden fazla sayfada yeniden kullanılan düzenler, ilgili `features` diliminde (slice) uygulanabilir.
+
+`shared` katmanındaki bir düzenin doğrudan `features`, `entities` veya `pages` katmanlarından içe aktarım (import) yapması [katmanlardaki içe aktarma kuralını][import-rule-on-layers] ihlal eder. `app` ve `pages` katmanlarındaki modüller bir ekranı oluşturmak (compose) için alt katmanlardaki modülleri içe aktarabilir.
+
+> Bir modül yalnızca ait olduğu katmanın altındaki katmanlardan modül içe aktarabilir.
+
+Bir düzeni ayrı bir modüle çıkarmadan önce şunları göz önünde bulundurun:
+
+* Bu düzen gerçekten birden fazla rota genelinde yeniden kullanılıyor mu?
+* Belirli bir sayfaya veya rota yapısına özgü mü?
+* Yeniden kullanılabilir birim düzenin kendisi mi, yoksa yalnızca düzen içinde kullanılan kullanıcı eylemi mi?
+
+Yalnızca az sayıda sayfa tarafından kullanılan ve belirli bir ekran yapısına bağlı olan bir düzeni, doğrudan ilgili `page` veya rota yapılandırmasında tanımlamak daha basit olabilir.
+
+1. **App katmanında bir rota düzeni yapılandırın**  
+   Yönlendiricinin iç içe geçme özelliklerini kullanarak ortak URL yoluna sahip birden fazla rotayı gruplayabilir ve `app` katmanında tek bir düzen atayabilirsiniz.
+   `app` içinde yer alan bir düzen, katmanlardaki içe aktarma kuralını ihlal etmeden `pages`, `features`, `entities` ve `shared` katmanlarındaki modülleri bir araya getirebilir (compose).
+
+2. **Özellik (Feature) UI bileşenlerini render props veya slot'lar aracılığıyla aktarın**  
+   React'te [render props][ext-render-props] desenini kullanabilirsiniz. Vue'da ise [slots][ext-vue-slots] kullanabilirsiniz.
+   Bu yaklaşımda `shared` içindeki düzen yalnızca ortak UI yapısını sağlarken, gerekli olan özellik UI bileşeni `app` veya `pages` katmanından aktarılır. Bu, düzenin belirli bir özelliğe doğrudan bağımlı olmadan gerekli ekranı oluşturmasını (compose) sağlar.
+
+3. **Doğrudan bir sayfa içinde tanımlayın**  
+   Yalnızca belirli bir sayfa tarafından kullanılan bir düzen, ayrı bir soyutlama eklenmeden doğrudan ilgili `page` içinde tanımlanabilir.
+   Kod tekrarı az olduğunda ve düzenin sık sık değişmesi muhtemel olmadığında, onu ortak bir modüle ayırmaya gerek yoktur.
+
+## Daha fazla okuma
+
+- React ve Remix (React Router'a eşdeğer) ile kimlik doğrulama içeren bir düzenin nasıl kurulacağına dair bir örnek [öğreticide][tutorial] bulunmaktadır.
+
+[tutorial]: /tr/docs/get-started/tutorial
+[import-rule-on-layers]: /tr/docs/reference/layers#import-rule-on-layers
+[ext-react-router]: https://reactrouter.com/
+[ext-render-props]: https://www.patterns.dev/react/render-props-pattern/
+[ext-vue-slots]: https://vuejs.org/guide/components/slots

--- a/src/content/docs/tr/docs/guides/examples/types.mdx
+++ b/src/content/docs/tr/docs/guides/examples/types.mdx
@@ -38,7 +38,7 @@ Bir `shared/types` klasörü oluşturma veya dilimlerinize bir `types` segmenti 
 
 </Aside>
 
-## İş varlıkları (Business entities) ve çapraz referansları
+## İş varlıkları (Business entities) ve çapraz referansları \{#business-entities-and-their-cross-references\}
 
 Bir uygulamadaki en önemli tipler arasında iş varlıklarının (business entities) tipleri yer alır; yani uygulamanızın çalıştığı gerçek dünya nesneleri. Örneğin, bir müzik akış uygulamasında *Song* (Şarkı), *Album* (Albüm) vb. iş varlıklarınız olabilir.
 

--- a/src/content/docs/tr/docs/guides/migration/from-custom.mdx
+++ b/src/content/docs/tr/docs/guides/migration/from-custom.mdx
@@ -8,7 +8,7 @@ import { FileTree, Aside } from '@astrojs/starlight/components';
 
 Bu kılavuz, özel (kendi geliştirdiğiniz) bir mimariden Feature-Sliced Design'a (FSD) geçiş yaparken yardımcı olabilecek bir yaklaşımı açıklamaktadır.
 
-İşte tipik bir özel mimarinin klasör yapısı. Bu kılavuzda bunu bir örnek olarak kullanacağız.  
+İşte tipik bir özel mimarinin klasör yapısı. Bu kılavuzda bunu bir örnek olarak kullanacağız.
 Klasörü açmak için mavi oka tıklayın.
 
 <FileTree>
@@ -44,7 +44,7 @@ Geçiş yapmayı düşünmek için bazı nedenler şunlardır:
 2. Kodun bir bölümünde değişiklik yapmak **sıklıkla** alakasız başka bir bölümün bozulmasına neden oluyorsa
 3. Düşünmeniz gereken şeylerin çokluğu nedeniyle yeni işlevsellik eklemek zorsa
 
-**Ekip arkadaşlarınızın isteği dışında FSD'ye geçmekten kaçının**, lider siz olsanız bile.  
+**Ekip arkadaşlarınızın isteği dışında FSD'ye geçmekten kaçının**, lider siz olsanız bile.
 Öncelikle ekip arkadaşlarınızı, geçişin maliyetinden ve kurulu olan yerine yeni bir mimari öğrenmenin maliyetinden daha fazla fayda sağladığına ikna edin.
 
 Ayrıca, her türlü mimari değişikliğin yönetim tarafından anında gözlemlenemeyeceğini de unutmayın. Başlamadan önce bu geçişi onayladıklarından emin olun ve bunun projeye neden fayda sağlayabileceğini açıklayın.
@@ -136,9 +136,9 @@ Sonuç olarak şöyle bir dosya yapısına sahip olmalısınız:
 Bir sayfanın diğerinden import edildiği tüm örnekleri bulun ve şu iki şeyden birini yapın:
 
 1. Bağımlılığı ortadan kaldırmak için import edilen kodu bağımlı sayfaya kopyalayıp yapıştırın (copy-paste).
-2. Kodu Shared içinde uygun bir segmente taşıyın: 
-      - eğer UI kitinin bir parçasıysa, onu `📁 shared/ui`'a taşıyın; 
-      - eğer bir yapılandırma sabitiyse (configuration constant), onu `📁 shared/config`'e taşıyın; 
+2. Kodu Shared içinde uygun bir segmente taşıyın:
+      - eğer UI kitinin bir parçasıysa, onu `📁 shared/ui`'a taşıyın;
+      - eğer bir yapılandırma sabitiyse (configuration constant), onu `📁 shared/config`'e taşıyın;
       - eğer bir backend etkileşimi ise, onu `📁 shared/api`'ye taşıyın.
 
 <Aside>
@@ -231,4 +231,4 @@ Eskiden `📁 components` ve `📁 containers` içinde bulunan UI bileşenlerini
 - [(Rusça Konuşma) Ilya Klimov — Крысиные бега бесконечного рефакторинга: как не дать техническому долгу убить мотивацию и продукт](https://youtu.be/aOiJ3k2UvO4)
 
 [ext-steiger]: https://github.com/feature-sliced/steiger
-[business-entities-cross-relations]: /tr/docs/guides/examples/types#iş-varlıkları-business-entities-ve-çapraz-referansları
+[business-entities-cross-relations]: /tr/docs/guides/examples/types#business-entities-and-their-cross-references

--- a/src/content/docs/tr/docs/guides/migration/from-custom.mdx
+++ b/src/content/docs/tr/docs/guides/migration/from-custom.mdx
@@ -1,0 +1,234 @@
+---
+title: Özel bir mimariden
+sidebar:
+  order: 1
+---
+
+import { FileTree, Aside } from '@astrojs/starlight/components';
+
+Bu kılavuz, özel (kendi geliştirdiğiniz) bir mimariden Feature-Sliced Design'a (FSD) geçiş yaparken yardımcı olabilecek bir yaklaşımı açıklamaktadır.
+
+İşte tipik bir özel mimarinin klasör yapısı. Bu kılavuzda bunu bir örnek olarak kullanacağız.  
+Klasörü açmak için mavi oka tıklayın.
+
+<FileTree>
+- src/
+  - actions/
+    - product/
+    - order/
+  - api/
+  - components/
+  - containers/
+  - constants/
+  - i18n/
+  - modules/
+  - helpers/
+  - routes/
+    - products.jsx
+    - products.[id].jsx
+  - utils/
+  - reducers/
+  - selectors/
+  - styles/
+  - App.jsx
+  - index.jsx
+</FileTree>
+
+## Başlamadan önce \{#before-you-start\}
+
+Feature-Sliced Design'a geçmeyi düşünürken ekibinize sormanız gereken en önemli soru şudur: _buna gerçekten ihtiyacınız var mı?_ Feature-Sliced Design'ı seviyoruz, ancak bazı projelerin onsuz da gayet iyi olduğunu kabul ediyoruz.
+
+Geçiş yapmayı düşünmek için bazı nedenler şunlardır:
+
+1. Yeni ekip üyeleri üretken bir seviyeye gelmenin zor olduğundan şikayet ediyorsa
+2. Kodun bir bölümünde değişiklik yapmak **sıklıkla** alakasız başka bir bölümün bozulmasına neden oluyorsa
+3. Düşünmeniz gereken şeylerin çokluğu nedeniyle yeni işlevsellik eklemek zorsa
+
+**Ekip arkadaşlarınızın isteği dışında FSD'ye geçmekten kaçının**, lider siz olsanız bile.  
+Öncelikle ekip arkadaşlarınızı, geçişin maliyetinden ve kurulu olan yerine yeni bir mimari öğrenmenin maliyetinden daha fazla fayda sağladığına ikna edin.
+
+Ayrıca, her türlü mimari değişikliğin yönetim tarafından anında gözlemlenemeyeceğini de unutmayın. Başlamadan önce bu geçişi onayladıklarından emin olun ve bunun projeye neden fayda sağlayabileceğini açıklayın.
+
+<Aside type="tip">
+
+FSD'nin faydalı olduğu konusunda proje yöneticisini ikna etmek için yardıma ihtiyacınız varsa, şu noktaları göz önünde bulundurun:
+1. FSD'ye geçiş kademeli olarak gerçekleşebilir, bu nedenle yeni özelliklerin geliştirilmesini durdurmaz.
+2. İyi bir mimari, yeni bir geliştiricinin üretken hale gelmesi için gereken süreyi önemli ölçüde azaltabilir.
+3. FSD belgelenmiş bir mimaridir, bu nedenle ekip sürekli olarak kendi belgelerini korumak için zaman harcamak zorunda kalmaz.
+
+</Aside>
+
+---
+
+Geçiş yapmaya karar verdiyseniz, yapmak isteyeceğiniz ilk şey `📁 src` için bir takma ad (alias) ayarlamaktır. Daha sonra üst düzey klasörlere başvurmak faydalı olacaktır. Bu kılavuzun geri kalanında `@` işaretini `./src` için bir takma ad olarak kabul edeceğiz.
+
+## 1. Adım: Kodu sayfalara göre bölün \{#divide-code-by-pages\}
+
+Çoğu özel mimari, mantık olarak küçük veya büyük olsun, zaten sayfalara göre bir bölüme sahiptir. Zaten `📁 pages` klasörünüz varsa bu adımı atlayabilirsiniz.
+
+Yalnızca `📁 routes` klasörünüz varsa, `📁 pages` oluşturun ve mümkün olduğunca çok bileşen kodunu `📁 routes`'tan taşımaya çalışın. İdeal olarak, küçük bir rotanız (route) ve daha büyük bir sayfanız (page) olmalıdır. Kodu taşırken, her sayfa için bir klasör oluşturun ve bir index dosyası ekleyin:
+
+<Aside>
+
+Şimdilik sayfalarınızın birbirine referans vermesi sorun değil. Bunu daha sonra ele alabilirsiniz, ancak şimdilik sayfalara göre belirgin bir bölüm (division) oluşturmaya odaklanın.
+
+</Aside>
+
+Rota dosyası (Route file):
+
+```js title="src/routes/products.[id].js"
+export { ProductPage as default } from "@/pages/product"
+```
+
+Sayfa dizin dosyası (Page index file):
+
+```js title="src/pages/product/index.js"
+export { ProductPage } from "./ProductPage.jsx"
+```
+
+Sayfa bileşen dosyası (Page component file):
+
+```jsx title="src/pages/product/ProductPage.jsx"
+export function ProductPage(props) {
+  return <div />;
+}
+```
+
+## 2. Adım: Diğer her şeyi sayfalardan ayırın \{#separate-everything-else-from-pages\}
+
+Bir `📁 src/shared` klasörü oluşturun ve `📁 pages` veya `📁 routes`'tan import edilmeyen her şeyi oraya taşıyın. Bir `📁 src/app` klasörü oluşturun ve rotaların kendileri de dahil olmak üzere sayfaları veya rotaları import eden her şeyi oraya taşıyın.
+
+Shared katmanının dilimleri (slices) olmadığını unutmayın, bu nedenle segmentlerin birbirinden import etmesinde bir sakınca yoktur.
+
+Sonuç olarak şöyle bir dosya yapısına sahip olmalısınız:
+
+<FileTree>
+- src/
+  - app/
+    - routes/
+      - products.jsx
+      - products.[id].jsx
+    - App.jsx
+    - index.js
+  - pages/
+    - product/
+      - index.js
+      - ui/
+        - ProductPage.jsx
+    - catalog/
+  - shared/
+    - actions/
+    - api/
+    - components/
+    - containers/
+    - constants/
+    - i18n/
+    - modules/
+    - helpers/
+    - utils/
+    - reducers/
+    - selectors/
+    - styles/
+</FileTree>
+
+## 3. Adım: Sayfalar arasındaki çapraz import'ları (cross-imports) ele alın \{#tackle-cross-imports-between-pages\}
+
+Bir sayfanın diğerinden import edildiği tüm örnekleri bulun ve şu iki şeyden birini yapın:
+
+1. Bağımlılığı ortadan kaldırmak için import edilen kodu bağımlı sayfaya kopyalayıp yapıştırın (copy-paste).
+2. Kodu Shared içinde uygun bir segmente taşıyın: 
+      - eğer UI kitinin bir parçasıysa, onu `📁 shared/ui`'a taşıyın; 
+      - eğer bir yapılandırma sabitiyse (configuration constant), onu `📁 shared/config`'e taşıyın; 
+      - eğer bir backend etkileşimi ise, onu `📁 shared/api`'ye taşıyın.
+
+<Aside>
+
+**Kopyala-yapıştır mimari açıdan yanlış değildir**, aslında bazen yeniden kullanılabilir yeni bir modül olarak soyutlamaktansa çoğaltmak daha doğru olabilir. Bunun nedeni, bazen sayfaların paylaşılan kısımlarının birbirinden uzaklaşmaya (drifting apart) başlamasıdır ve bu gibi durumlarda bağımlılıkların yolunuza çıkmasını istemezsiniz.
+
+Ancak, DRY ("kendini tekrar etme - don't repeat yourself") prensibinde hala bir mantık vardır, bu nedenle iş mantığını (business logic) kopyalayıp yapıştırmadığınızdan emin olun. Aksi takdirde, hataları aynı anda birkaç yerde düzeltmeyi hatırlamanız gerekecektir.
+
+</Aside>
+
+## 4. Adım: Shared katmanını açın (Unpack) \{#unpack-shared-layer\}
+
+Bu adımda Shared katmanında çok fazla şeyiniz olabilir ve genel olarak bundan kaçınmak istersiniz. Bunun nedeni, Shared katmanının kod tabanınızdaki (codebase) diğer herhangi bir katman için bir bağımlılık olabilmesidir, bu nedenle bu kodda değişiklik yapmak otomatik olarak istenmeyen sonuçlara (unintended consequences) daha yatkındır.
+
+Yalnızca bir sayfada kullanılan tüm nesneleri (objects) bulun ve onu o sayfanın dilimine (slice) taşıyın. Ve evet, _bu durum eylemler (actions), indirgeyiciler (reducers) ve seçiciler (selectors) için de geçerlidir_. Tüm eylemleri birlikte gruplandırmanın bir faydası yoktur, ancak ilgili eylemleri kullanımlarına yakın olacak şekilde (colocating) konumlandırmanın faydası vardır.
+
+Sonuç olarak şöyle bir dosya yapısına sahip olmalısınız:
+
+<FileTree>
+- src/
+  - app/
+    - ...
+  - pages/
+    - product/
+      - actions/
+      - reducers/
+      - selectors/
+      - ui/
+        - Component.jsx
+        - Container.jsx
+        - ProductPage.jsx
+      - index.js
+    - catalog/
+  - shared/ yalnızca yeniden kullanılan nesneler (only objects that are reused)
+    - actions/
+    - api/
+    - components/
+    - containers/
+    - constants/
+    - i18n/
+    - modules/
+    - helpers/
+    - utils/
+    - reducers/
+    - selectors/
+    - styles/
+</FileTree>
+
+## 5. Adım: Kodu teknik amacına göre düzenleyin \{#organize-by-technical-purpose\}
+
+FSD'de teknik amaca göre bölümleme _segmentler_ ile yapılır. Yaygın olanlardan birkaçı şunlardır:
+
+- `ui` — UI gösterimiyle ilgili her şey: UI bileşenleri, tarih biçimlendiricileri, stiller vb.
+- `api` — backend etkileşimleri: istek fonksiyonları, veri tipleri, eşleyiciler (mappers) vb.
+- `model` — veri modeli: şemalar, arayüzler (interfaces), depolar (stores) ve iş mantığı.
+- `lib` — bu dilimdeki diğer modüllerin ihtiyaç duyduğu kütüphane (library) kodu.
+- `config` — yapılandırma dosyaları ve özellik bayrakları (feature flags).
+
+İhtiyaç duyarsanız kendi segmentlerinizi de oluşturabilirsiniz. Kodu ne olduğuna göre gruplandıran `components`, `actions`, `types`, `utils` gibi segmentler oluşturmadığınızdan emin olun. Bunun yerine, kodu ne işe yaradığına göre gruplandırın.
+
+Kodu segmentlere ayırmak için sayfalarınızı yeniden düzenleyin. Zaten bir `ui` segmentiniz olmalı, şimdi eylemleriniz, indirgeyicileriniz ve seçicileriniz için `model` veya thunk'lar ve mutasyonlarınız için `api` gibi diğer segmentleri oluşturma zamanı.
+
+Ayrıca şu klasörleri kaldırmak için Shared katmanını da yeniden düzenleyin:
+- `📁 components`, `📁 containers` — bunların çoğu `📁 shared/ui` olmalıdır;
+- `📁 helpers`, `📁 utils` — eğer geride kalmış bazı yardımcılar varsa, bunları tarihler veya tip dönüşümleri (type conversions) gibi işlevlerine göre gruplayın ve bu grupları `📁 shared/lib` içine taşıyın;
+- `📁 constants` — yine işlevine göre gruplandırın ve `📁 shared/config` içine taşıyın.
+
+## İsteğe bağlı adımlar \{#optional-steps\}
+
+### 6. Adım: Birkaç sayfada kullanılan Redux dilimlerinden varlıklar/özellikler (entities/features) oluşturun \{#form-entities-features-from-redux\}
+
+Genellikle, bu yeniden kullanılan Redux dilimleri işletmeyle ilgili bir şeyi tanımlayacaktır, örneğin ürünler (products) veya kullanıcılar (users), bu nedenle bunlar her klasörde bir varlık (entity) olacak şekilde Entities katmanına taşınabilir. Redux dilimi, uygulamanızda kullanıcılarınızın yapmak istediği yorumlar gibi bir eylemle ilgiliyse, bunu Features katmanına taşıyabilirsiniz.
+
+Varlıkların (Entities) ve özelliklerin (features) birbirinden bağımsız olması amaçlanmıştır. İş alanınız (business domain) varlıklar arasında doğal bağlantılar içeriyorsa, bu bağlantıları nasıl organize edeceğiniz konusunda tavsiye için [iş varlıkları kılavuzuna][business-entities-cross-relations] başvurun.
+
+Bu dilimlerle ilgili API fonksiyonları `📁 shared/api` içinde kalabilir.
+
+### 7. Adım: Modüllerinizi yeniden düzenleyin (Refactor) \{#refactor-your-modules\}
+
+`📁 modules` klasörü genellikle iş mantığı (business logic) için kullanılır, bu nedenle doğası gereği FSD'deki Features katmanına oldukça benzerdir. Bazı modüller ayrıca uygulama başlığı (app header) gibi UI'ın büyük kısımlarını da tanımlayabilir. Bu durumda, onları Widgets katmanına taşımalısınız.
+
+### 8. Adım: `shared/ui` içinde temiz bir UI temeli oluşturun \{#form-clean-ui-foundation\}
+
+`📁 shared/ui`, ideal olarak içlerinde hiçbir iş mantığı kodlanmamış bir dizi UI öğesi içermelidir. Ayrıca son derece yeniden kullanılabilir olmalıdırlar.
+
+Eskiden `📁 components` ve `📁 containers` içinde bulunan UI bileşenlerini, iş mantığını ayırmak için yeniden düzenleyin (refactor). Bu iş mantığını daha üst katmanlara taşıyın. Eğer çok fazla yerde kullanılmıyorsa, kopyalayıp yapıştırmayı bile düşünebilirsiniz.
+
+## Ayrıca bakınız \{#see-also\}
+
+- [(Rusça Konuşma) Ilya Klimov — Крысиные бега бесконечного рефакторинга: как не дать техническому долгу убить мотивацию и продукт](https://youtu.be/aOiJ3k2UvO4)
+
+[ext-steiger]: https://github.com/feature-sliced/steiger
+[business-entities-cross-relations]: /tr/docs/guides/examples/types#iş-varlıkları-business-entities-ve-çapraz-referansları


### PR DESCRIPTION
## Background

Relates to #934. 
Continuing the Turkish localization effort. This PR adds the translation for the from a custom architecture section.

## Changelog

* Translated the from a custom architecture  page (`src/content/docs/tr/docs/guides/migration/from-custom.mdx`)