### PR TITLE
feat: add edit and article request links to the page footer

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,10 +30,16 @@ export default defineConfig({
             description: "Architectural methodology for frontend projects",
             defaultLocale: "root",
             customCss: ["./src/styles/custom.css"],
+            editLink: {
+                baseUrl:
+                    "https://github.com/feature-sliced/documentation/edit/main/",
+            },
             components: {
                 /* Adds the per-page social preview image, see `src/pages/og/[...path].ts`. */
                 Head: "./src/shared/ui/Head.astro",
                 ThemeProvider: "./src/shared/ui/ThemeProvider.astro",
+                /* Replaces the edit link, see `src/shared/ui/EditLink.astro`. */
+                EditLink: "./src/shared/ui/EditLink.astro",
             },
             logo: {
                 src: "./static/img/brand/logo-primary.png",

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,4 @@
+/* `remark-heading-id` ships no type declarations. It reaches TypeScript only
+   because `tsconfig.astro.json` includes `astro.config.mjs`, the file that loads
+   Starlight's `App.Locals` augmentation. */
+declare module "remark-heading-id";

--- a/src/shared/ui/EditLink.astro
+++ b/src/shared/ui/EditLink.astro
@@ -1,0 +1,43 @@
+---
+/* Replaces Starlight's edit link so that both labels stay in English on every
+   locale. Starlight translates its own `page.editLink` string per locale. */
+import { Icon } from "@astrojs/starlight/components";
+
+const requestUrl =
+    "https://github.com/feature-sliced/documentation/discussions/new?category=ideas";
+
+const { editUrl, entry } = Astro.locals.starlightRoute;
+/* Neither link fits the landing page: it is built from the components in
+   `src/pages/_pages/ui/`, so its source file has nothing to edit. */
+const isSplash = entry.data.template === "splash";
+---
+
+{
+    !isSplash && (
+        <>
+            {editUrl && (
+                <a href={editUrl} class="print:hidden">
+                    <Icon name="pencil" size="1.2em" />
+                    Edit page
+                </a>
+            )}
+            <a href={requestUrl} class="print:hidden">
+                <Icon name="comment-alt" size="1.2em" />
+                Request an article
+            </a>
+        </>
+    )
+}
+
+<style>
+    a {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        text-decoration: none;
+        color: var(--sl-color-gray-3);
+    }
+    a:hover {
+        color: var(--sl-color-white);
+    }
+</style>

--- a/tsconfig.astro.json
+++ b/tsconfig.astro.json
@@ -1,6 +1,6 @@
 {
     "extends": "astro/tsconfigs/strict",
-    "include": [".astro/types.d.ts", "src/**/*"],
+    "include": [".astro/types.d.ts", "src/**/*", "astro.config.mjs"],
     "exclude": ["dist", "build"],
     "compilerOptions": {
         "baseUrl": ".",


### PR DESCRIPTION
## Background

I created this PR to address #256.

At first, I considered closing the issue as `Not Planned`, but I thought it could still be useful to give readers of the official documentation a more approachable way to suggest topics they would like to see covered.

There are already several channels where people can leave feedback, such as Issues, Discussions, and the community, but I thought having an entry point directly within the documentation could make it a bit easier for readers to naturally turn those thoughts into documentation requests.

So I added `Edit page` and `Request an article` links to the bottom of documentation pages. `Request an article` links to the `Ideas` category in Discussions, where documentation-related ideas are already being shared.

Originally, I wanted to discuss the direction with Solant, who usually reviews these changes, before working on the UI. Since Solant is currently on vacation and the scope of the change is relatively small, I went ahead and put together a quick proposal first. If there is a better way to approach this through Issues or Discussions, I would be happy to discuss it in #256 and adjust the implementation accordingly.

I see this as a small UI addition that provides readers with a slightly easier way to participate in improving the documentation without significantly changing the existing documentation flow.

<p align="center">
  <img
    src="https://github.com/user-attachments/assets/9f631a3b-80b1-422b-9757-06914d22a083"
    width="850"
    alt="Request an article and Edit page links in the documentation footer"
  />
</p>