### PR TITLE
feat: add missing telegram link

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -149,6 +149,11 @@ export default defineConfig({
                     href: "https://github.com/feature-sliced/documentation",
                 },
                 {
+                    icon: "telegram",
+                    label: "Telegram",
+                    href: "https://t.me/feature_sliced",
+                },
+                {
                     icon: "discord",
                     label: "Discord",
                     href: "https://discord.gg/S8MzWTUsmp",


### PR DESCRIPTION
## Background

Telegram group link is missing from the header

## Changelog

Telegram group link is added to the header